### PR TITLE
Fix error when parsing WareEffect#Product failed

### DIFF
--- a/X4_DataExporterWPF/Export/Ware/WareEffectExporter.cs
+++ b/X4_DataExporterWPF/Export/Ware/WareEffectExporter.cs
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS WareEffect
                                 var effectID = effect.Attribute("type")?.Value;
                                 if (string.IsNullOrEmpty(effectID)) return null;
 
-                                var product = double.Parse(effect.Attribute("product")?.Value ?? "0.0");
+                                double.TryParse(effect.Attribute("product")?.Value, out var product);
 
                                 return new WareEffect(wareID, method, effectID, product);
                             }


### PR DESCRIPTION
WareEffect#Product のパースに失敗した場合、エラーを出す代わりに 0.0 として扱うよう変更。

参照: #5 
