### PR TITLE
Ignore ModuleOwner that specify non-existent factionID

### DIFF
--- a/X4_ComplexCalculator/DB/X4DB/Faction.cs
+++ b/X4_ComplexCalculator/DB/X4DB/Faction.cs
@@ -70,7 +70,8 @@ namespace X4_ComplexCalculator.DB.X4DB
         /// </summary>
         /// <param name="factionID">派閥ID</param>
         /// <returns>派閥</returns>
-        public static Faction Get(string factionID) => _Factions[factionID];
+        public static Faction? Get(string factionID)
+            => _Factions.TryGetValue(factionID, out var faction) ? faction : null;
 
 
         /// <summary>

--- a/X4_ComplexCalculator/DB/X4DB/Module.cs
+++ b/X4_ComplexCalculator/DB/X4DB/Module.cs
@@ -101,7 +101,8 @@ namespace X4_ComplexCalculator.DB.X4DB
                 var moduleOwners = new List<Faction>();
                 DBConnection.X4DB.ExecQuery($"SELECT FactionID FROM ModuleOwner WHERE ModuleID = '{id}'", (dr2, args2) =>
                 {
-                    moduleOwners.Add(Faction.Get((string)dr2["FactionID"]));
+                    var faction = Faction.Get((string)dr2["FactionID"]);
+                    if (faction != null) moduleOwners.Add(faction);
                 });
 
                 var prod = (noBlueprint) ? Array.Empty<ModuleProduction>() : ModuleProduction.Get(id);

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/FactionsListItem.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/FactionsListItem.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Mvvm;
+﻿using System;
+using Prism.Mvvm;
 using X4_ComplexCalculator.DB.X4DB;
 
 namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid.EditEquipment
@@ -58,7 +59,8 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid.EditEquipment
         /// <param name="isChecked">チェック状態</param>
         public FactionsListItem(string id, bool isChecked)
         {
-            Faction = Faction.Get(id);
+            var faction = Faction.Get(id);
+            Faction = faction ?? throw new ArgumentException("${id} is illegal factionID.");
             IsChecked = isChecked;
         }
     }

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/FactionsListItem.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/FactionsListItem.cs
@@ -60,7 +60,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid.EditEquipment
         public FactionsListItem(string id, bool isChecked)
         {
             var faction = Faction.Get(id);
-            Faction = faction ?? throw new ArgumentException("${id} is illegal factionID.");
+            Faction = faction ?? throw new ArgumentException("${id} is invalid factionID.");
             IsChecked = isChecked;
         }
     }


### PR DESCRIPTION
自由部族をモジュール所有派閥に設定する MOD を導入している場合、抽出後に起動に失敗するのを修正。
存在しない派閥をモジュール所有派閥に設定している場合は無視する X4 本体の仕様に合わせた。