### PR TITLE
Fix CatFile#OpenFile and more

### DIFF
--- a/LibX4/FileSystem/CatFile.cs
+++ b/LibX4/FileSystem/CatFile.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -95,25 +95,15 @@ namespace LibX4.FileSystem
         /// <returns>ファイルの内容</returns>
         public MemoryStream OpenFile(string filePath)
         {
-            {
-                using var ret = _VanillaFile.OpenFile(filePath);
-
-                // バニラのデータに見つかればそちらを開く
-                if (ret != null)
-                {
-                    return ret;
-                }
-            }
+            // バニラのデータに見つかればそちらを開く
+            var vanillaFile = _VanillaFile.OpenFile(filePath);
+            if (vanillaFile != null) return vanillaFile;
 
             // バニラのデータに見つからない場合、Modのデータを探しに行く
             foreach (var fileLoader in _ModFiles.Values)
             {
-                using var ret = fileLoader.OpenFile(filePath);
-
-                if (ret != null)
-                {
-                    return ret;
-                }
+                var modFile = fileLoader.OpenFile(filePath);
+                if (modFile != null) return modFile;
             }
 
             throw new FileNotFoundException(nameof(filePath));

--- a/LibX4/FileSystem/CatFile.cs
+++ b/LibX4/FileSystem/CatFile.cs
@@ -32,12 +32,6 @@ namespace LibX4.FileSystem
 
 
         /// <summary>
-        /// XML差分適用用ユーティリティクラス
-        /// </summary>
-        private readonly XMLPatcher _XMLPatcher = new XMLPatcher();
-
-
-        /// <summary>
         /// Modのファイルパスを分割する正規表現
         /// </summary>
         private readonly Regex _ParseModRegex = new Regex(@"(extensions\/.+?)\/(.+)");
@@ -143,7 +137,7 @@ namespace LibX4.FileSystem
                 }
                 else
                 {
-                    _XMLPatcher.MergeXML(ret, XDocument.Load(ms));
+                    ret.MergeXML(XDocument.Load(ms));
                 }
             }
 
@@ -210,7 +204,7 @@ namespace LibX4.FileSystem
                 if (src.Root.Name.LocalName == "diff")
                 {
                     // 差分ファイルの場合、パッチ処理に差分を適用させる
-                    _XMLPatcher.MergeXML(ret, src);
+                    ret.MergeXML(src);
                 }
                 else
                 {

--- a/LibX4/FileSystem/CatFile.cs
+++ b/LibX4/FileSystem/CatFile.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using System.Xml.XPath;
-using X4_DataExporterWPF.Common;
-using System.Text.RegularExpressions;
-using X4_DataExporterWPF.Export;
-using System.Linq;
 
 namespace LibX4.FileSystem
 {

--- a/LibX4/FileSystem/ModInfo.cs
+++ b/LibX4/FileSystem/ModInfo.cs
@@ -1,7 +1,7 @@
-﻿using System.IO;
+using System.IO;
 using System.Xml.Linq;
 
-namespace X4_DataExporterWPF.Export
+namespace LibX4.FileSystem
 {
 
     /// <summary>

--- a/LibX4/FileSystem/XMLPatcher.cs
+++ b/LibX4/FileSystem/XMLPatcher.cs
@@ -5,7 +5,7 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
-namespace X4_DataExporterWPF.Common
+namespace LibX4.FileSystem
 {
     /// <summary>
     /// XML差分パッチ用クラス

--- a/LibX4/FileSystem/XMLPatcher.cs
+++ b/LibX4/FileSystem/XMLPatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Linq;
 using System.Xml;
@@ -15,82 +15,77 @@ namespace LibX4.FileSystem
     /// なお、現時点では名前空間のマングリングを伴うパッチ(RFC5261 の A.18)以外は
     /// 期待する内容と同じ意味になるxmlが作成される。
     /// </remarks>
-    public class XMLPatcher
+    static class XMLPatcher
     {
         /// <summary>
-        /// コンストラクタ
+        /// Xml ファイルに別の Xml ファイルをマージする
         /// </summary>
-        public XMLPatcher()
+        /// <param name="baseXml">ベースとなる XML</param>
+        /// <param name="patchXml">マージする XML</param>
+        public static void MergeXML(this XDocument baseXml, XDocument patchXml)
         {
-
+            if (patchXml.Root.Name.LocalName == "diff") ApplyDiffXml(baseXml, patchXml);
+            else baseXml.Root.Add(patchXml.Root.Elements());
         }
 
 
         /// <summary>
-        /// xmlファイルをマージする
+        /// Xml ファイルに RFC5261 に準拠した diff XML をマージする
         /// </summary>
-        /// <param name="patchedXml">パッチされるxml</param>
-        /// <param name="patchXml">パッチ用xml</param>
-        public void MergeXML(XDocument patchedXml, XDocument patchXml)
+        /// <param name="baseXml">ベースとなる XML</param>
+        /// <param name="diffXml">RFC5261 に準拠した diff XML</param>
+        private static void ApplyDiffXml(XDocument baseXml, XDocument diffXml)
         {
-            if (patchXml.Root.Name.LocalName == "diff")
+            var nsMng = new XmlNamespaceManager(new NameTable());
+
+            foreach (var attr in diffXml.Root.Attributes())
             {
-                var nsTbl = new NameTable();
-                var nsMng = new XmlNamespaceManager(nsTbl);
-
-                foreach (var attr in patchXml.Root.Attributes())
+                // 名前空間の場合
+                if (attr.IsNamespaceDeclaration)
                 {
-                    // 名前空間の場合
-                    if (attr.IsNamespaceDeclaration)
+                    if (attr.Name.LocalName.StartsWith("xmlns"))
                     {
-                        if (attr.Name.LocalName.StartsWith("xmlns"))
-                        {
-                            nsMng.AddNamespace(attr.Name.NamespaceName, attr.Value);
-                        }
-                        else
-                        {
-                            nsMng.AddNamespace(attr.Name.LocalName, attr.Value);
-                        }
+                        nsMng.AddNamespace(attr.Name.NamespaceName, attr.Value);
                     }
-                }
-
-                foreach (var elm in patchXml.Root.Elements())
-                {
-                    var sel = patchedXml.XPathEvaluate(elm.Attribute("sel").Value, nsMng);
-
-                    if (!(sel is IEnumerable enumerable))
+                    else
                     {
-                        continue;
-                    }
-
-                    var targetNode = enumerable.OfType<XObject>().FirstOrDefault();
-                    if (targetNode == null)
-                    {
-                        continue;
-                    }
-
-                    switch (elm.Name.LocalName)
-                    {
-                        case "add":
-                            AddNode(elm, targetNode);
-                            break;
-
-                        case "replace":
-                            Replace(elm, targetNode);
-                            break;
-
-                        case "remove":
-                            Remove(patchedXml, targetNode);
-                            break;
-
-                        default:
-                            break;
+                        nsMng.AddNamespace(attr.Name.LocalName, attr.Value);
                     }
                 }
             }
-            else
+
+            foreach (var elm in diffXml.Root.Elements())
             {
-                patchedXml.Root.Add(patchXml.Root.Elements());
+                var sel = baseXml.XPathEvaluate(elm.Attribute("sel").Value, nsMng);
+
+                if (!(sel is IEnumerable enumerable))
+                {
+                    continue;
+                }
+
+                var targetNode = enumerable.OfType<XObject>().FirstOrDefault();
+                if (targetNode == null)
+                {
+                    continue;
+                }
+
+                switch (elm.Name.LocalName)
+                {
+                    case "add":
+                        AddNode(elm, targetNode);
+                        break;
+
+                    case "replace":
+                        Replace(elm, targetNode);
+                        break;
+
+                    case "remove":
+                        Remove(baseXml, targetNode);
+                        break;
+
+                    default:
+                        break;
+                }
             }
         }
 
@@ -101,7 +96,7 @@ namespace LibX4.FileSystem
         /// <param name="dst"></param>
         /// <param name="element"></param>
         /// <param name="target"></param>
-        private void AddNode(XElement element, XObject target)
+        private static void AddNode(XElement element, XObject target)
         {
             var type = element.Attribute("type")?.Value;
 
@@ -158,7 +153,7 @@ namespace LibX4.FileSystem
         /// </summary>
         /// <param name="element"></param>
         /// <param name="target"></param>
-        private void Replace(XElement element, XObject target)
+        private static void Replace(XElement element, XObject target)
         {
             switch (target.NodeType)
             {
@@ -187,7 +182,7 @@ namespace LibX4.FileSystem
         /// </summary>
         /// <param name="dst"></param>
         /// <param name="element"></param>
-        private void Remove(XDocument dst, XObject target)
+        private static void Remove(XDocument dst, XObject target)
         {
             switch (target.NodeType)
             {

--- a/X4_DataExporterWPF/ExportWindow/DataExportModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportModel.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
-using System.Drawing.Printing;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Xml.XPath;
 using LibX4.FileSystem;
@@ -127,7 +125,7 @@ namespace X4_DataExporterWPF.DataExportWindow
                     currentStep++;
                     progless.Report((currentStep, maxSteps));
                 }
-                
+
                 trans.Commit();
 
                 MessageBox.Show("Data export completed.", "X4 DataExporter", MessageBoxButton.OK, MessageBoxImage.Information);

--- a/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.IO;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -112,7 +113,7 @@ namespace X4_DataExporterWPF.DataExportWindow
             CloseCommand = new ReactiveCommand<Window>(CanOperation).WithSubscribe(Close);
 
             // 入力元フォルダパスが変更された時、言語一覧を更新する
-            InDirPath.Subscribe(path =>
+            InDirPath.ObserveOn(ThreadPoolScheduler.Instance).Subscribe(path =>
             {
                 Langages.ClearOnScheduler();
                 Langages.AddRangeOnScheduler(_Model.GetLangages(path));

--- a/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.WindowsAPICodePack.Dialogs;
-using Prism.Mvvm;
-using Reactive.Bindings;
-using Reactive.Bindings.Extensions;
 using System;
 using System.IO;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using Microsoft.WindowsAPICodePack.Dialogs;
+using Prism.Mvvm;
+using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
 
 namespace X4_DataExporterWPF.DataExportWindow
 {


### PR DESCRIPTION
- :bug: `CatFile#OpenFile` で Dispose 済みの Stream が返される不具合を修正
- :bug: ModInfo 及び XMLPatcher の名前空間を `LibX4.FileSystem` に移動
- :recycle: `XMLPatcher.MergeXML` を拡張メソッドに変更
- :zap: DataExporter の対応言語の取得をワーカースレッドで行うように変更