### PR TITLE
Change build settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ jobs:
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
 
+    strategy:
+      matrix:
+        Configuration: [Debug, Release]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -22,7 +26,7 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build -c Debug --no-restore
+        run: dotnet build -c ${{ matrix.Configuration }} --no-restore
 
       - name: Test
         run: dotnet test
@@ -30,5 +34,5 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: X4_ComplexCalculator-${{ github.sha }}
-          path: X4_ComplexCalculator/bin/Debug/netcoreapp3.1
+          name: X4_ComplexCalculator-${{ matrix.Configuration }}-${{ github.sha }}
+          path: X4_ComplexCalculator/bin/${{ matrix.Configuration }}/netcoreapp3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: dotnet restore -r win-x64
 
       - name: Build
-        run: dotnet build -c Release -r win-x64 /p:PublishReadyToRun=true --no-restore
+        run: dotnet build -c Release -r win-x64 --no-restore
 
       - name: Compress archive
         run: |

--- a/LibX4/LibX4.csproj
+++ b/LibX4/LibX4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/LibX4/LibX4.csproj
+++ b/LibX4/LibX4.csproj
@@ -5,12 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>

--- a/X4_ComplexCalculator/X4_ComplexCalculator.csproj
+++ b/X4_ComplexCalculator/X4_ComplexCalculator.csproj
@@ -7,18 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
-    <Optimize>false</Optimize>
-    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
-    <Optimize>true</Optimize>
-    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>

--- a/X4_ComplexCalculator/X4_ComplexCalculator.csproj
+++ b/X4_ComplexCalculator/X4_ComplexCalculator.csproj
@@ -12,6 +12,10 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(SelfContained)'=='true'">
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.35" />
     <PackageReference Include="Dirkster.AvalonDock" Version="4.30.0" />

--- a/X4_ComplexCalculator_CustomControlLibrary/X4_ComplexCalculator_CustomControlLibrary.csproj
+++ b/X4_ComplexCalculator_CustomControlLibrary/X4_ComplexCalculator_CustomControlLibrary.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>

--- a/X4_ComplexCalculator_CustomControlLibrary/X4_ComplexCalculator_CustomControlLibrary.csproj
+++ b/X4_ComplexCalculator_CustomControlLibrary/X4_ComplexCalculator_CustomControlLibrary.csproj
@@ -11,4 +11,8 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(SelfContained)'=='true'">
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+
 </Project>

--- a/X4_DataExporterWPF/X4_DataExporterWPF.csproj
+++ b/X4_DataExporterWPF/X4_DataExporterWPF.csproj
@@ -11,6 +11,10 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(SelfContained)'=='true'">
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.35" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />

--- a/X4_DataExporterWPF/X4_DataExporterWPF.csproj
+++ b/X4_DataExporterWPF/X4_DataExporterWPF.csproj
@@ -6,14 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- push 時に Release ビルドも行うように変更

- LibX4 のターケットフレームワークを .Net Core 3.1 から .Net Standard 2.1 に変更

- 各 csproj から PlatformTarget, Prefer32Bit, Optimize, GenerateSerializationAssemblies の指定を削除
  + PlatformTarget はビルド時の Runtime オプションで指定する
  + Prefer32Bit はデフォルトで false なので指定不要っぽい
  + Optimize は Debug ビルド時のデフォルトは false、Release ビルド時のデフォルトは true っぽいので指定不要と判断
  + GenerateSerializationAssemblies はデフォルトで Auto なので指定不要っぽい

- ~~SatelliteResourceLanguages を有効化~~
  + AvalonDock の関係ないローケル用の dll が多数含まれるのを抑制するための設定 (4MB くらい減った)
  + 不思議な挙動が見られるので revert

- ランタイム不要ビルド時に PublishReadyToRun, ~~PublishTrimmed~~ を有効化
  + PublishReadyToRun はビルド時に指定していたのを移しただけ
  + ~~PublishTrimmed は一応設定した。もしかしたら意味ないかもしれない~~ デフォルトで有効っぽいので削除