### PR TITLE
Add tests and refactor LanguageResolver

### DIFF
--- a/LibX4.Tests/LanguageResolverTest.cs
+++ b/LibX4.Tests/LanguageResolverTest.cs
@@ -53,7 +53,7 @@ namespace LibX4.Tests
 
 
         /// <summary>
-        /// 解決後の文字列に言語フィールド文字列が含まれる場合、再帰的に処理する
+        /// 解決後の文字列に言語フィールド文字列が含まれる場合、再帰的に解決する
         /// </summary>
         [Fact]
         public void Recursion()
@@ -69,6 +69,48 @@ namespace LibX4.Tests
             </language>
             ".ToXDocument()).Resolve("{1001,5802}");
             Assert.Equal("Planned Amount of Graphene", resolve);
+        }
+
+
+        /// <summary>
+        /// 解決後の文字列に言語フィールド文字列が含まれる場合、含まれなくなるまで再帰的に解決する
+        /// </summary>
+        [Fact]
+        public void DoubleSolution()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""1001"">
+                     <t id=""5802"">Planned Amount of {20201, 1501}</t>
+                </page>
+                <page id=""20201"">
+                    <t id=""1501"">{20201, 1502}</t>
+                    <t id=""1502"">Graphene</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{1001,5802}");
+            Assert.Equal("Planned Amount of Graphene", resolve);
+        }
+
+
+        /// <summary>
+        /// 解決後の文字列に言語フィールド文字列が 2 つ以上含まれる場合、全て解決する
+        /// </summary>
+        [Fact]
+        public void TwoPointResolve()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""20101"">
+                    <t id=""10101"">Discoverer</t>
+                    <t id=""10102"">(Discoverer Vanguard){20101,10101} {20111,1101}</t>
+                </page>
+                <page id=""20111"">
+                    <t id=""1101"">Vanguard</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{20101,10102}");
+            Assert.Equal("Discoverer Vanguard", resolve);
         }
 
 
@@ -104,6 +146,74 @@ namespace LibX4.Tests
             </language>
             ".ToXDocument()).Resolve("{1001,2490}");
             Assert.Equal("Shield Generators (including groups)", resolve);
+        }
+
+
+        /// <summary>
+        /// コメントと括弧が重なっている場合の解決 1
+        /// </summary>
+        [Fact]
+        public void MixingCommentsAndBrankets_1()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""1"">
+                    <t id=""1"">aaaa\(bbbb(cccc)\)</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{1,1}");
+            Assert.Equal("aaaa(bbbb)", resolve);
+        }
+
+
+        /// <summary>
+        /// コメントと括弧が重なっている場合の解決 2
+        /// </summary>
+        [Fact]
+        public void MixingCommentsAndBrankets_2()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""1"">
+                    <t id=""1"">aaaa\(bbbb(cc\)cc)</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{1,1}");
+            Assert.Equal("aaaa(bbbb", resolve);
+        }
+
+
+        /// <summary>
+        /// コメントと括弧が重なっている場合の解決 3
+        /// </summary>
+        [Fact]
+        public void MixingCommentsAndBrankets_3()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""1"">
+                    <t id=""1"">aaaa(\(bbbb)cc\)cc</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{1,1}");
+            Assert.Equal("aaaacc)cc", resolve);
+        }
+
+
+        /// <summary>
+        /// コメントと括弧が重なっている場合の解決 4
+        /// </summary>
+        [Fact]
+        public void MixingCommentsAndBrankets_4()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""1"">
+                    <t id=""1"">aaaa(\(bbbb\)cc)cc</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{1,1}");
+            Assert.Equal("aaaacc", resolve);
         }
     }
 }

--- a/LibX4.Tests/LanguageResolverTest.cs
+++ b/LibX4.Tests/LanguageResolverTest.cs
@@ -21,14 +21,14 @@ namespace LibX4.Tests
                 </page>
             </language>
             ".ToXDocument();
-            var langXml2st = @"
+            var langXml2nd = @"
             <language>
                 <page id=""1001"">
                      <t id=""1"">Hull</t>
                 </page>
             </language>
             ".ToXDocument();
-            var resolve = new LanguageResolver(langXml1st, langXml2st).Resolve("{1001,1}");
+            var resolve = new LanguageResolver(langXml1st, langXml2nd).Resolve("{1001,1}");
             Assert.Equal("船体", resolve);
         }
 

--- a/LibX4.Tests/LanguageResolverTest.cs
+++ b/LibX4.Tests/LanguageResolverTest.cs
@@ -76,7 +76,7 @@ namespace LibX4.Tests
         /// 解決後の文字列に言語フィールド文字列が含まれる場合、含まれなくなるまで再帰的に解決する
         /// </summary>
         [Fact]
-        public void DoubleSolution()
+        public void MultipleRecursion()
         {
             var resolve = new LanguageResolver(@"
             <language>
@@ -97,7 +97,7 @@ namespace LibX4.Tests
         /// 解決後の文字列に言語フィールド文字列が 2 つ以上含まれる場合、全て解決する
         /// </summary>
         [Fact]
-        public void TwoPointResolve()
+        public void MultipleFieldResolve()
         {
             var resolve = new LanguageResolver(@"
             <language>

--- a/LibX4.Tests/LanguageResolverTest.cs
+++ b/LibX4.Tests/LanguageResolverTest.cs
@@ -1,0 +1,109 @@
+﻿using LibX4.Lang;
+using Xunit;
+
+namespace LibX4.Tests
+{
+    /// <summary>
+    /// <see cref="LanguageResolver"/> のテストクラス
+    /// </summary>
+    public class LanguageResolverTest
+    {
+        /// <summary>
+        /// 最初に指定された XML を優先する
+        /// </summary>
+        [Fact]
+        public void PreferFirstSpecifiedXml()
+        {
+            var langXml1st = @"
+            <language>
+                <page id=""1001"">
+                     <t id=""1"">船体</t>
+                </page>
+            </language>
+            ".ToXDocument();
+            var langXml2st = @"
+            <language>
+                <page id=""1001"">
+                     <t id=""1"">Hull</t>
+                </page>
+            </language>
+            ".ToXDocument();
+            var resolve = new LanguageResolver(langXml1st, langXml2st).Resolve("{1001,1}");
+            Assert.Equal("船体", resolve);
+        }
+
+
+        /// <summary>
+        /// 最初に指定された XML に無かった場合、次の XML を参照する
+        /// </summary>
+        [Fact]
+        public void ReadNextXmlIfNotFound()
+        {
+            var langXml1st = "<language></language>".ToXDocument();
+            var langXml2st = @"
+            <language>
+                <page id=""1001"">
+                     <t id=""1"">Hull</t>
+                </page>
+            </language>
+            ".ToXDocument();
+            var resolve = new LanguageResolver(langXml1st, langXml2st).Resolve("{1001,1}");
+            Assert.Equal("Hull", resolve);
+        }
+
+
+        /// <summary>
+        /// 解決後の文字列に言語フィールド文字列が含まれる場合、再帰的に処理する
+        /// </summary>
+        [Fact]
+        public void Recursion()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""1001"">
+                     <t id=""5802"">Planned Amount of {20201, 1501}</t>
+                </page>
+                <page id=""20201"">
+                    <t id=""1501"">Graphene</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{1001,5802}");
+            Assert.Equal("Planned Amount of Graphene", resolve);
+        }
+
+
+        /// <summary>
+        /// 括弧で囲われた文字列はコメントとして扱い、削除する
+        /// </summary>
+        [Fact]
+        public void BranketsIsComment()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""1001"">
+                     <t id=""9"">(Storage)None</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{1001,9}");
+            Assert.Equal("None", resolve);
+        }
+
+
+        /// <summary>
+        /// 括弧の前にバックスペースがある場合、
+        /// バックスペースを除去した上で括弧を通常の文字として扱う。
+        /// </summary>
+        [Fact]
+        public void BranketsEscape()
+        {
+            var resolve = new LanguageResolver(@"
+            <language>
+                <page id=""1001"">
+                    <t id=""2490"">Shield Generators \(including groups\)</t>
+                </page>
+            </language>
+            ".ToXDocument()).Resolve("{1001,2490}");
+            Assert.Equal("Shield Generators (including groups)", resolve);
+        }
+    }
+}

--- a/LibX4.Tests/LibX4.Tests.csproj
+++ b/LibX4.Tests/LibX4.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LibX4.Tests/LibX4.Tests.csproj
+++ b/LibX4.Tests/LibX4.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LibX4\LibX4.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LibX4.Tests/TestHelperExtension.cs
+++ b/LibX4.Tests/TestHelperExtension.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using System.Xml.Linq;
+
+namespace LibX4.Tests
+{
+    /// <summary>
+    /// LibX4.Tests 用のユーティリティクラス
+    /// </summary>
+    internal static class TestHelperExtension
+    {
+        /// <summary>
+        /// 文字列から文頭文末の改行及び各行のインデントを取り除く
+        /// </summary>
+        /// <param name="source">対象の文字列</param>
+        /// <returns>文頭文末の改行及び各行のインデントを取り除いた文字列</returns>
+        public static string TrimIndent(this string source)
+        {
+            var lines = source.Split("\n").ToList();
+            if (string.IsNullOrWhiteSpace(lines.First())) lines.RemoveAt(0);
+            if (string.IsNullOrWhiteSpace(lines.Last())) lines.RemoveAt(lines.Count - 1);
+            var indent = lines
+                .Where(l => !string.IsNullOrWhiteSpace(l))
+                .Select(l => l.TakeWhile(c => char.IsWhiteSpace(c)).Count())
+                .Min();
+            return string.Join("\n", lines.Select(l => l.Substring(indent)));
+        }
+
+
+        /// <summary>
+        /// 文字列を XML として読み込む
+        /// </summary>
+        /// <param name="source">XML として読み込む文字列</param>
+        /// <returns>読み込んだ XML</returns>
+        public static XDocument ToXDocument(this string source)
+            => XDocument.Parse(source.TrimIndent());
+    }
+}

--- a/LibX4/AssemblyInfo.cs
+++ b/LibX4/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("LibX4.Tests")]

--- a/LibX4/Lang/LanguageResolver.cs
+++ b/LibX4/Lang/LanguageResolver.cs
@@ -7,31 +7,31 @@ using LibX4.FileSystem;
 namespace LibX4.Lang
 {
     /// <summary>
-    /// X4の言語フィールド文字列を解決するクラス
+    /// X4 の言語フィールド文字列 (例: {1001,2490}) を解決するクラス
     /// </summary>
     public class LanguageResolver
     {
         #region メンバ
         /// <summary>
-        /// 言語ファイルのスタック
+        /// 読み込んだ言語 XML
         /// </summary>
         private readonly XDocument[] _LanguagesXml;
 
 
         /// <summary>
-        /// メッセージテンプレートからIDを抽出する正規表現
+        /// 言語フィールド文字列から pageID, tID を抽出する正規表現
         /// </summary>
         private static readonly Regex _GetIDRegex = new Regex(@"\{\s*(\d+)\s*,\s*(\d+)\s*\}");
 
 
         /// <summary>
-        /// コメント削除用正規表現
+        /// エスケープされていない括弧とその内部を削除する正規表現
         /// </summary>
         private static readonly Regex _RemoveCommentRegex = new Regex(@"(?<!\\)\((?:|.*[^\\])\)");
 
 
         /// <summary>
-        /// 括弧のエスケープを解除する正規表現
+        /// エスケープを解除する正規表現
         /// </summary>
         private static readonly Regex _UnescapeRegex = new Regex(@"\\(.)");
         #endregion

--- a/LibX4/Lang/LanguageResolver.cs
+++ b/LibX4/Lang/LanguageResolver.cs
@@ -38,6 +38,14 @@ namespace LibX4.Lang
 
 
         /// <summary>
+        /// 指定された言語 XML で LanguageResolver インスタンスを初期化する。
+        /// 複数の言語 XML が指定された場合、先に指定された物を優先する。
+        /// </summary>
+        /// <param name="languageXml">参照する言語 XML</param>
+        internal LanguageResolver(params XDocument[] languageXml) => _LanguagesXml = languageXml;
+
+
+        /// <summary>
         /// 指定された言語 ID のファイルを読み込み、LanguageResolver インスタンスを初期化する。
         /// 複数の言語 ID が指定された場合、先に指定された物を優先する。
         /// </summary>

--- a/LibX4/Lang/LanguageResolver.cs
+++ b/LibX4/Lang/LanguageResolver.cs
@@ -27,7 +27,7 @@ namespace LibX4.Lang
         /// <summary>
         /// コメント削除用正規表現
         /// </summary>
-        private static readonly Regex _RemoveCommentRegex = new Regex(@"(?<!\\)\(.*?(?<!\\)\)");
+        private static readonly Regex _RemoveCommentRegex = new Regex(@"(?<!\\)\((?:|.*[^\\])\)");
 
 
         /// <summary>
@@ -63,66 +63,34 @@ namespace LibX4.Lang
 
 
         /// <summary>
-        /// 言語フィールドの文字列を言語ファイルを参照して解決する
+        /// 言語フィールド文字列 (例: {1001,2490}) を解決する
         /// </summary>
-        /// <param name="template">言語フィールド文字列</param>
-        /// <returns>解決結果文字列</returns>
-        public string Resolve(string template)
+        /// <param name="target">言語フィールド文字列を含む文字列</param>
+        /// <returns>言語フィールド文字列を解決し置き換えた文字列</returns>
+        public string Resolve(string target)
         {
-            if (string.IsNullOrEmpty(template))
+            if (string.IsNullOrEmpty(target)) return target;
+
+            var matchLangField = _GetIDRegex.Match(target);
+            if (matchLangField == null) return target;
+            var pageID = matchLangField.Groups[1].Value;
+            var tID = matchLangField.Groups[2].Value;
+
+            foreach (var languageXml in _LanguagesXml)
             {
-                return template;
-            }
-
-            foreach (var langTree in _LanguagesXml)
-            {
-                var textOld = "";
-                var textNew = template;
-                var succeeded = false;
-
-                while (textOld != textNew)
+                var findT = languageXml.Root
+                    .XPathSelectElement($"./page[@id='{pageID}']/t[@id='{tID}']")
+                    ?.Value;
+                if (findT != null)
                 {
-                    textOld = textNew;
-                    bool succededTmp;
-
-                    (textNew, succededTmp) = ResolveField(textNew, langTree);
-
-                    succeeded |= succededTmp;
-                }
-
-                // 名前解決に成功したか？
-                if (succeeded)
-                {
-                    return _UnescapeRegex.Replace(textNew, @"$1");
+                    var uncommentedT = _RemoveCommentRegex.Replace(findT, "");
+                    var resolvedText = target.Replace(matchLangField.Value, uncommentedT);
+                    var unescapedText = _UnescapeRegex.Replace(resolvedText, "$1");
+                    return Resolve(unescapedText);
                 }
             }
 
-            return template;
-        }
-
-
-        /// <summary>
-        /// 言語フィールド解決処理メイン
-        /// </summary>
-        /// <param name="text">言語フィールド文字列</param>
-        /// <param name="langTree">翻訳対象言語のXDocument</param>
-        /// <returns></returns>
-        private (string, bool) ResolveField(string text, XDocument langTree)
-        {
-            var match = _GetIDRegex.Match(text);
-
-            var pageID = match.Groups[1].Value;
-            var tID = match.Groups[2].Value;
-
-            var nodes = langTree.Root.XPathSelectElements($"./page[@id='{pageID}']/t[@id='{tID}']");
-            if (nodes == null || !nodes.Any())
-            {
-                return (text, false);
-            }
-
-            // コメントアウト削除
-            var ret = _RemoveCommentRegex.Replace(nodes.First().Value, "");
-            return (text.Replace(match.Value, ret), true);
+            return target;
         }
     }
 }

--- a/X4_ComplexCalculator.sln
+++ b/X4_ComplexCalculator.sln
@@ -9,7 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "X4_ComplexCalculator_Custom
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibX4", "LibX4\LibX4.csproj", "{DAC31A3D-9432-4D7D-9A9A-F5052017AB5D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "X4_DataExporterWPF", "X4_DataExporterWPF\X4_DataExporterWPF.csproj", "{B4315308-79F8-4F96-B6D2-F66FF8B001C6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "X4_DataExporterWPF", "X4_DataExporterWPF\X4_DataExporterWPF.csproj", "{B4315308-79F8-4F96-B6D2-F66FF8B001C6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibX4.Tests", "LibX4.Tests\LibX4.Tests.csproj", "{1EEA0D64-A038-4C8C-8E54-2CDEF906A28C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{B4315308-79F8-4F96-B6D2-F66FF8B001C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4315308-79F8-4F96-B6D2-F66FF8B001C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4315308-79F8-4F96-B6D2-F66FF8B001C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EEA0D64-A038-4C8C-8E54-2CDEF906A28C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EEA0D64-A038-4C8C-8E54-2CDEF906A28C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EEA0D64-A038-4C8C-8E54-2CDEF906A28C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EEA0D64-A038-4C8C-8E54-2CDEF906A28C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
LibX4 用のテストプロジェクトを作成し、`LanguageResolver` のテストを追加。
ついでに `LanguageResolver#Resolve` の処理を単純化。

XDocument で持つより、pageID と tID をキーにした Dictionary にしたほうが早いのでは？
と思って試してみたが、大した違いは無かったので止めた。
