### PR TITLE
Better export ui

### DIFF
--- a/X4_DataExporterWPF/ExportWindow/DataExportModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportModel.cs
@@ -20,17 +20,17 @@ namespace X4_DataExporterWPF.DataExportWindow
         /// <summary>
         /// 言語一覧を更新
         /// </summary>
-        public (bool success, IEnumerable<LangComboboxItem> languages) GetLangages(string inDirPath)
+        public (bool success, IEnumerable<LangComboboxItem> languages) GetLanguages(string inDirPath)
         {
             try
             {
                 var catFiles = new CatFile(inDirPath);
                 var xml = catFiles.OpenXml("libraries/languages.xml");
-                var langages = xml.XPathSelectElements("/languages/language")
+                var languages = xml.XPathSelectElements("/languages/language")
                     .Select(x => new LangComboboxItem(int.Parse(x.Attribute("id").Value), x.Attribute("name").Value))
                     .OrderBy(x => x.ID);
 
-                return (true, langages);
+                return (true, languages);
             }
             catch (Exception)
             {

--- a/X4_DataExporterWPF/ExportWindow/DataExportModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportModel.cs
@@ -20,7 +20,7 @@ namespace X4_DataExporterWPF.DataExportWindow
         /// <summary>
         /// 言語一覧を更新
         /// </summary>
-        public IEnumerable<LangComboboxItem> GetLangages(string inDirPath)
+        public (bool success, IEnumerable<LangComboboxItem> languages) GetLangages(string inDirPath)
         {
             try
             {
@@ -30,11 +30,11 @@ namespace X4_DataExporterWPF.DataExportWindow
                     .Select(x => new LangComboboxItem(int.Parse(x.Attribute("id").Value), x.Attribute("name").Value))
                     .OrderBy(x => x.ID);
 
-                return langages;
+                return (true, langages);
             }
             catch (Exception)
             {
-                return Enumerable.Empty<LangComboboxItem>();
+                return (false, Enumerable.Empty<LangComboboxItem>());
             }
         }
 

--- a/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -104,7 +105,8 @@ namespace X4_DataExporterWPF.DataExportWindow
         {
             IsBusy = _BusyNotifier.ToReadOnlyReactivePropertySlim();
 
-            InDirPath = new ReactivePropertySlim<string>(inDirPath);
+            InDirPath = new ReactivePropertySlim<string>(inDirPath,
+                mode: ReactivePropertyMode.RaiseLatestValueOnSubscribe);
             _OutFilePath = outFilePath;
 
             Langages = new ReactiveCollection<LangComboboxItem>();
@@ -126,7 +128,7 @@ namespace X4_DataExporterWPF.DataExportWindow
             ExportCommand = new AsyncReactiveCommand(canExport, CanOperation).WithSubscribe(Export);
             CloseCommand = new ReactiveCommand<Window>(CanOperation).WithSubscribe(Close);
 
-            // 入力元フォルダパスが変更された時、言語一覧を更新する
+            // 入力元フォルダパスに値が代入された時、言語一覧を更新する
             InDirPath.ObserveOn(ThreadPoolScheduler.Instance).Subscribe(path =>
             {
                 using var _ = _BusyNotifier.ProcessStart();

--- a/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
@@ -33,7 +33,7 @@ namespace X4_DataExporterWPF.DataExportWindow
         /// <summary>
         /// 入力元フォルダパス
         /// </summary>
-        public ReactiveProperty<string> InDirPath { get; }
+        public ReactivePropertySlim<string> InDirPath { get; }
 
 
         /// <summary>
@@ -45,25 +45,25 @@ namespace X4_DataExporterWPF.DataExportWindow
         /// <summary>
         /// 選択された言語
         /// </summary>
-        public ReactiveProperty<LangComboboxItem?> SelectedLangage { get; }
+        public ReactivePropertySlim<LangComboboxItem?> SelectedLangage { get; }
 
 
         /// <summary>
         /// 進捗最大
         /// </summary>
-        public ReactiveProperty<int> MaxSteps { get; }
+        public ReactivePropertySlim<int> MaxSteps { get; }
 
 
         /// <summary>
         /// 現在の進捗
         /// </summary>
-        public ReactiveProperty<int> CurrentStep { get; }
+        public ReactivePropertySlim<int> CurrentStep { get; }
 
 
         /// <summary>
         /// ユーザが操作可能か
         /// </summary>
-        public ReactiveProperty<bool> CanOperation { get; }
+        public ReactivePropertySlim<bool> CanOperation { get; }
 
 
         /// <summary>
@@ -90,16 +90,16 @@ namespace X4_DataExporterWPF.DataExportWindow
         /// </summary>
         public DataExportViewModel(string inDirPath, string outFilePath)
         {
-            InDirPath = new ReactiveProperty<string>(inDirPath);
+            InDirPath = new ReactivePropertySlim<string>(inDirPath);
             _OutFilePath = outFilePath;
 
             Langages = new ReactiveCollection<LangComboboxItem>();
-            SelectedLangage = new ReactiveProperty<LangComboboxItem?>();
+            SelectedLangage = new ReactivePropertySlim<LangComboboxItem?>();
 
-            MaxSteps = new ReactiveProperty<int>(1);
-            CurrentStep = new ReactiveProperty<int>(0);
+            MaxSteps = new ReactivePropertySlim<int>(1);
+            CurrentStep = new ReactivePropertySlim<int>(0);
 
-            CanOperation = new ReactiveProperty<bool>(true);
+            CanOperation = new ReactivePropertySlim<bool>(true);
 
             // 操作可能かつ入力項目に不備がない場合に true にする
             var canExport = new[]{

--- a/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
@@ -59,13 +59,13 @@ namespace X4_DataExporterWPF.DataExportWindow
         /// <summary>
         /// 言語一覧
         /// </summary>
-        public ReactiveCollection<LangComboboxItem> Langages { get; }
+        public ReactiveCollection<LangComboboxItem> Languages { get; }
 
 
         /// <summary>
         /// 選択された言語
         /// </summary>
-        public ReactivePropertySlim<LangComboboxItem?> SelectedLangage { get; }
+        public ReactivePropertySlim<LangComboboxItem?> SelectedLanguage { get; }
 
 
         /// <summary>
@@ -119,8 +119,8 @@ namespace X4_DataExporterWPF.DataExportWindow
                 _ => _InDirPathHasError.Select(isError => isError ? "Error" : null));
             _OutFilePath = outFilePath;
 
-            Langages = new ReactiveCollection<LangComboboxItem>();
-            SelectedLangage = new ReactivePropertySlim<LangComboboxItem?>();
+            Languages = new ReactiveCollection<LangComboboxItem>();
+            SelectedLanguage = new ReactivePropertySlim<LangComboboxItem?>();
 
             MaxSteps = new ReactivePropertySlim<int>(1);
             CurrentStep = new ReactivePropertySlim<int>(0);
@@ -131,7 +131,7 @@ namespace X4_DataExporterWPF.DataExportWindow
             var canExport = new[]{
                 CanOperation,
                 InDirPath.Select(p => !string.IsNullOrEmpty(p)),
-                SelectedLangage.Select(l => l != null),
+                SelectedLanguage.Select(l => l != null),
             }.CombineLatestValuesAreAllTrue();
 
             SelectInDirCommand = new ReactiveCommand(CanOperation).WithSubscribe(SelectInDir);
@@ -143,11 +143,11 @@ namespace X4_DataExporterWPF.DataExportWindow
             {
                 using var _ = _BusyNotifier.ProcessStart();
                 _InDirPathHasError.Value = false;
-                Langages.ClearOnScheduler();
+                Languages.ClearOnScheduler();
 
-                var (success, languages) = _Model.GetLangages(path);
+                var (success, languages) = _Model.GetLanguages(path);
                 _InDirPathHasError.Value = !success;
-                Langages.AddRangeOnScheduler(languages);
+                Languages.AddRangeOnScheduler(languages);
             });
         }
 
@@ -185,7 +185,7 @@ namespace X4_DataExporterWPF.DataExportWindow
             using var _ = _BusyNotifier.ProcessStart();
 
             // 言語が未選択なら何もしない
-            if (SelectedLangage.Value == null)
+            if (SelectedLanguage.Value == null)
             {
                 return;
             }
@@ -199,7 +199,7 @@ namespace X4_DataExporterWPF.DataExportWindow
                 progless,
                 InDirPath.Value,
                 _OutFilePath,
-                SelectedLangage.Value
+                SelectedLanguage.Value
             ));
             CurrentStep.Value = 0;
         }

--- a/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
+++ b/X4_DataExporterWPF/ExportWindow/DataExportViewModel.cs
@@ -33,7 +33,7 @@ namespace X4_DataExporterWPF.DataExportWindow
         /// <summary>
         /// 現在の入力元フォルダパスから言語一覧を取得できなかった場合 true
         /// </summary>
-        private readonly ReactivePropertySlim<bool> _InDirPathHasError;
+        private readonly ReactivePropertySlim<bool> _UnableToGetLanguages;
 
 
         /// <summary>
@@ -114,9 +114,9 @@ namespace X4_DataExporterWPF.DataExportWindow
 
             InDirPath = new ReactiveProperty<string>(inDirPath,
                 mode: ReactivePropertyMode.RaiseLatestValueOnSubscribe);
-            _InDirPathHasError = new ReactivePropertySlim<bool>(false);
+            _UnableToGetLanguages = new ReactivePropertySlim<bool>(false);
             InDirPath.SetValidateNotifyError(
-                _ => _InDirPathHasError.Select(isError => isError ? "Error" : null));
+                _ => _UnableToGetLanguages.Select(isError => isError ? "Error" : null));
             _OutFilePath = outFilePath;
 
             Languages = new ReactiveCollection<LangComboboxItem>();
@@ -142,11 +142,11 @@ namespace X4_DataExporterWPF.DataExportWindow
             InDirPath.ObserveOn(ThreadPoolScheduler.Instance).Subscribe(path =>
             {
                 using var _ = _BusyNotifier.ProcessStart();
-                _InDirPathHasError.Value = false;
+                _UnableToGetLanguages.Value = false;
                 Languages.ClearOnScheduler();
 
                 var (success, languages) = _Model.GetLanguages(path);
-                _InDirPathHasError.Value = !success;
+                _UnableToGetLanguages.Value = !success;
                 Languages.AddRangeOnScheduler(languages);
             });
         }

--- a/X4_DataExporterWPF/ExportWindow/DataExportWindow.xaml
+++ b/X4_DataExporterWPF/ExportWindow/DataExportWindow.xaml
@@ -14,6 +14,19 @@
     SizeToContent="Height"
     WindowStartupLocation="CenterOwner"
     mc:Ignorable="d">
+    <Window.Style>
+        <Style TargetType="Window">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsBusy.Value}" Value="false">
+                    <Setter Property="Cursor" Value="Arrow" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding IsBusy.Value}" Value="true">
+                    <Setter Property="Cursor" Value="Wait" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Style>
+
     <Grid>
 
         <Grid.RowDefinitions>

--- a/X4_DataExporterWPF/ExportWindow/DataExportWindow.xaml
+++ b/X4_DataExporterWPF/ExportWindow/DataExportWindow.xaml
@@ -98,8 +98,8 @@
                     Background="WhiteSmoke"
                     DisplayMemberPath="Name"
                     IsEnabled="{Binding CanOperation.Value, Mode=OneWay}"
-                    ItemsSource="{Binding Langages}"
-                    SelectedItem="{Binding SelectedLangage.Value, Mode=OneWayToSource}" />
+                    ItemsSource="{Binding Languages}"
+                    SelectedItem="{Binding SelectedLanguage.Value, Mode=OneWayToSource}" />
             </Grid>
         </GroupBox>
 


### PR DESCRIPTION
- ReactiveProperty を Slim 版に差し替え
- 言語一覧更新中、または抽出処理中はカーソルをリングに変更
- 入力元ディレクトリが変更されなかった場合でも言語一覧の更新を行うように変更
- 言語一覧の取得に失敗した場合、入力元ディレクトリ欄を赤くする
- タイポ修正