### PR TITLE
Refactoring LanguagesManager using ReactiveProperty

### DIFF
--- a/X4_ComplexCalculator/Main/MainWindow.xaml
+++ b/X4_ComplexCalculator/Main/MainWindow.xaml
@@ -162,7 +162,7 @@
                     <Style TargetType="{x:Type MenuItem}">
                         <Setter Property="MenuItem.Header" Value="{Binding CultureInfo.NativeName, Mode=OneTime}" />
                         <Setter Property="MenuItem.IsChecked" Value="{Binding IsChecked.Value, Mode=TwoWay}" />
-                        <Setter Property="MenuItem.IsCheckable" Value="True" />
+                        <Setter Property="MenuItem.IsCheckable" Value="{Binding IsCheckable.Value, Mode=OneWay}" />
                     </Style>
                 </MenuItem.ItemContainerStyle>
             </MenuItem>

--- a/X4_ComplexCalculator/Main/MainWindow.xaml
+++ b/X4_ComplexCalculator/Main/MainWindow.xaml
@@ -156,12 +156,12 @@
 
             <MenuItem
                 Header="{lex:Loc Lang:Language}"
-                ItemsSource="{Binding Languages}"
+                ItemsSource="{Binding Languages, Mode=OneTime}"
                 ToolBar.OverflowMode="Always">
                 <MenuItem.ItemContainerStyle>
                     <Style TargetType="{x:Type MenuItem}">
-                        <Setter Property="MenuItem.Header" Value="{Binding Name}" />
-                        <Setter Property="MenuItem.IsChecked" Value="{Binding IsChecked, Mode=TwoWay}" />
+                        <Setter Property="MenuItem.Header" Value="{Binding CultureInfo.NativeName, Mode=OneTime}" />
+                        <Setter Property="MenuItem.IsChecked" Value="{Binding IsChecked.Value, Mode=TwoWay}" />
                         <Setter Property="MenuItem.IsCheckable" Value="True" />
                     </Style>
                 </MenuItem.ItemContainerStyle>

--- a/X4_ComplexCalculator/Main/MainWindowViewModel.cs
+++ b/X4_ComplexCalculator/Main/MainWindowViewModel.cs
@@ -14,7 +14,6 @@ using GongSolutions.Wpf.DragDrop;
 using Prism.Commands;
 using Prism.Mvvm;
 using Reactive.Bindings;
-using X4_ComplexCalculator.Common.Collection;
 using X4_ComplexCalculator.Common.Localize;
 using X4_ComplexCalculator.Infrastructure;
 using X4_ComplexCalculator.Main.Menu.File.Export;
@@ -192,7 +191,7 @@ namespace X4_ComplexCalculator.Main
         /// <summary>
         /// 言語一覧
         /// </summary>
-        public ObservableRangeCollection<LangMenuItem> Languages => _LangMgr.Languages;
+        public IReadOnlyList<LangMenuItem> Languages => _LangMgr.Languages;
 
 
         /// <summary>

--- a/X4_ComplexCalculator/Main/Menu/Lang/LangMenuItem.cs
+++ b/X4_ComplexCalculator/Main/Menu/Lang/LangMenuItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Reactive.Linq;
 using Prism.Mvvm;
 using Reactive.Bindings;
 
@@ -20,6 +21,12 @@ namespace X4_ComplexCalculator.Main.Menu.Lang
         /// チェックされたか
         /// </summary>
         public ReactivePropertySlim<bool> IsChecked { get; }
+
+
+        /// <summary>
+        /// チェックを外すことはできない
+        /// </summary>
+        public ReadOnlyReactivePropertySlim<bool> IsCheckable { get; }
         #endregion
 
 
@@ -31,6 +38,7 @@ namespace X4_ComplexCalculator.Main.Menu.Lang
         {
             CultureInfo = cultureInfo;
             IsChecked = new ReactivePropertySlim<bool>(isChecked);
+            IsCheckable = IsChecked.Select(x => !x).ToReadOnlyReactivePropertySlim();
         }
     }
 }

--- a/X4_ComplexCalculator/Main/Menu/Lang/LangMenuItem.cs
+++ b/X4_ComplexCalculator/Main/Menu/Lang/LangMenuItem.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using Prism.Mvvm;
-using WPFLocalizeExtension.Engine;
-using X4_ComplexCalculator.Common;
+using Reactive.Bindings;
 
 namespace X4_ComplexCalculator.Main.Menu.Lang
 {
@@ -10,46 +9,17 @@ namespace X4_ComplexCalculator.Main.Menu.Lang
     /// </summary>
     public class LangMenuItem : BindableBase
     {
-        #region メンバ
+        #region プロパティ
         /// <summary>
         /// 言語
         /// </summary>
-        private readonly CultureInfo _CultureInfo;
+        public CultureInfo CultureInfo { get; }
 
 
         /// <summary>
         /// チェックされたか
         /// </summary>
-        private bool _IsChecked;
-        #endregion
-
-
-        #region プロパティ
-        /// <summary>
-        /// チェックされたか
-        /// </summary>
-        public bool IsChecked
-        {
-            get => _IsChecked;
-            set
-            {
-                if (SetProperty(ref _IsChecked, value))
-                {
-                    if (IsChecked)
-                    {
-                        LocalizeDictionary.Instance.Culture = _CultureInfo;
-
-                        Configuration.SetValue("AppSettings.Language", _CultureInfo.Name);
-                    }
-                }
-            }
-        }
-
-
-        /// <summary>
-        /// 言語名
-        /// </summary>
-        public string Name => _CultureInfo.NativeName;
+        public ReactivePropertySlim<bool> IsChecked { get; }
         #endregion
 
 
@@ -57,14 +27,10 @@ namespace X4_ComplexCalculator.Main.Menu.Lang
         /// コンストラクタ
         /// </summary>
         /// <param name="cultureInfo">言語情報</param>
-        public LangMenuItem(CultureInfo cultureInfo)
+        public LangMenuItem(CultureInfo cultureInfo, bool isChecked)
         {
-            _CultureInfo = cultureInfo;
-
-            if (cultureInfo.Name == LocalizeDictionary.CurrentCulture.Name)
-            {
-                IsChecked = true;
-            }
+            CultureInfo = cultureInfo;
+            IsChecked = new ReactivePropertySlim<bool>(isChecked);
         }
     }
 }


### PR DESCRIPTION
- LanguagesManager 及び LangMenuItem を ReactiveProperty を使ってリファクタリング
- `LocalizeDictionary.Instance.DefaultProvider.AvailableCultures` は `ObservableCollection` だが、更新されることはないと思われるので `Mode=OneTime` に変更
- ついでに言語のチェックを外せないように変更