### PR TITLE
Remove System.Reactive.xml from release build

### DIFF
--- a/X4_ComplexCalculator/X4_ComplexCalculator.csproj
+++ b/X4_ComplexCalculator/X4_ComplexCalculator.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <AllowedReferenceRelatedFileExtensions>none</AllowedReferenceRelatedFileExtensions>
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>


### PR DESCRIPTION
リリースビルド時に System.Reactive.xml (2.33MB) を出力しないように変更。
SOS_README.md (277B) も不要だがこちらは .NET 5 で出力されなくなるようなので放置。