### PR TITLE
Add Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/LibX4.Tests/LibX4.Tests.csproj
+++ b/LibX4.Tests/LibX4.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LibX4/LibX4.csproj
+++ b/LibX4/LibX4.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/X4_ComplexCalculator/X4_ComplexCalculator.csproj
+++ b/X4_ComplexCalculator/X4_ComplexCalculator.csproj
@@ -4,7 +4,6 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
-    <Nullable>enable</Nullable>
 
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>

--- a/X4_ComplexCalculator_CustomControlLibrary/X4_ComplexCalculator_CustomControlLibrary.csproj
+++ b/X4_ComplexCalculator_CustomControlLibrary/X4_ComplexCalculator_CustomControlLibrary.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/X4_DataExporterWPF.Tests/X4_DataExporterWPF.Tests.csproj
+++ b/X4_DataExporterWPF.Tests/X4_DataExporterWPF.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/X4_DataExporterWPF/X4_DataExporterWPF.csproj
+++ b/X4_DataExporterWPF/X4_DataExporterWPF.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
C# 9.0 に備えて言語バージョンと null 許容参照型の設定を共通設定 (`Directory.Build.props`) に切り出す
ついでにテストプロジェクトで null 許容参照型機能が有効化 (忘れてた)