### PR TITLE
Update WPFLocalizeExtension

### DIFF
--- a/X4_ComplexCalculator/Common/Behavior/ControlItemDoubleClick.cs
+++ b/X4_ComplexCalculator/Common/Behavior/ControlItemDoubleClick.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
-using System.ServiceModel.Channels;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 
 namespace X4_ComplexCalculator.Common.Behavior

--- a/X4_ComplexCalculator/Common/Localize/CSVLocalizationProvider.cs
+++ b/X4_ComplexCalculator/Common/Localize/CSVLocalizationProvider.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Management;
 using System.Text;
 using System.Windows;
+using WPFLocalizeExtension.Deprecated.Providers;
 using WPFLocalizeExtension.Engine;
 using WPFLocalizeExtension.Providers;
 

--- a/X4_ComplexCalculator/Localization/Lang.csv
+++ b/X4_ComplexCalculator/Localization/Lang.csv
@@ -56,6 +56,7 @@ SaveAs;Save as
 Open;Open
 Import;Import
 ExistingPlan;Existing plan
+StationCalculator;Station Calculator
 Export;Export
 UpdateDB;Update DB
 DBUpdateConfirmationMessage;Do you want to display the DB update screen? \r\nPlease wait for a moment until the screen starts.

--- a/X4_ComplexCalculator/Localization/Lang.en-US.csv
+++ b/X4_ComplexCalculator/Localization/Lang.en-US.csv
@@ -56,6 +56,7 @@ SaveAs;Save as
 Open;Open
 Import;Import
 ExistingPlan;Existing plan
+StationCalculator;Station Calculator
 Export;Export
 UpdateDB;Update DB
 DBUpdateConfirmationMessage;Do you want to display the DB update screen? \r\nPlease wait for a moment until the screen starts.

--- a/X4_ComplexCalculator/Localization/Lang.ja-JP.csv
+++ b/X4_ComplexCalculator/Localization/Lang.ja-JP.csv
@@ -56,6 +56,7 @@ SaveAs;名前を付けて保存
 Open;開く
 Import;インポート
 ExistingPlan;既存の計画
+StationCalculator;Station Calculator
 Export;エクスポート
 UpdateDB;DB更新
 DBUpdateConfirmationMessage;DB更新画面を表示しますか？\r\n※ 画面が起動するまでしばらくお待ち下さい。

--- a/X4_ComplexCalculator/Main/MainWindow.xaml
+++ b/X4_ComplexCalculator/Main/MainWindow.xaml
@@ -94,7 +94,17 @@
                     ItemsSource="{Binding Imports}">
                     <MenuItem.ItemContainerStyle>
                         <Style TargetType="{x:Type MenuItem}">
-                            <Setter Property="MenuItem.Header" Value="{Binding Title, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Setter Property="MenuItem.Header">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{lex:TranslateConverter}" Mode="OneWay">
+                                        <Binding Mode="OneTime" Path="Title" />
+                                        <Binding
+                                            Mode="OneWay"
+                                            Path="Culture"
+                                            Source="{x:Static lex:LocalizeDictionary.Instance}" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
                             <Setter Property="Command" Value="{Binding Command, Mode=OneTime}" />
                             <Setter Property="CommandParameter" Value="{Binding ., Mode=OneTime}" />
                         </Style>
@@ -108,7 +118,18 @@
                     ItemsSource="{Binding Exports}">
                     <MenuItem.ItemContainerStyle>
                         <Style TargetType="{x:Type MenuItem}">
-                            <Setter Property="MenuItem.Header" Value="{Binding Title, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Setter Property="MenuItem.Header">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{lex:TranslateConverter}" Mode="OneWay">
+                                        <Binding Mode="OneTime" Path="Title" />
+                                        <Binding
+                                            Mode="OneWay"
+                                            Path="Culture"
+                                            Source="{x:Static lex:LocalizeDictionary.Instance}" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="MenuItem.Header" Value="{Binding Title, Mode=OneWay, Converter={lex:TranslateConverter}}" />
                             <Setter Property="Command" Value="{Binding Command, Mode=OneTime}" />
                             <Setter Property="CommandParameter" Value="{Binding ., Mode=OneTime}" />
                         </Style>

--- a/X4_ComplexCalculator/Main/Menu/File/Export/StationCalculatorExport.cs
+++ b/X4_ComplexCalculator/Main/Menu/File/Export/StationCalculatorExport.cs
@@ -15,7 +15,7 @@ namespace X4_ComplexCalculator.Main.Menu.File.Export
         /// <summary>
         /// タイトル文字列
         /// </summary>
-        public string Title => "Station Calculator";
+        public string Title => "Lang:StationCalculator";
 
 
         /// <summary>

--- a/X4_ComplexCalculator/Main/Menu/File/Import/LoadoutImport/LoadoutImport.cs
+++ b/X4_ComplexCalculator/Main/Menu/File/Import/LoadoutImport/LoadoutImport.cs
@@ -1,6 +1,5 @@
 ﻿using System.Windows.Input;
 using Prism.Mvvm;
-using WPFLocalizeExtension.Engine;
 using X4_ComplexCalculator.Main.WorkArea;
 
 namespace X4_ComplexCalculator.Main.Menu.File.Import.LoadoutImport
@@ -13,7 +12,7 @@ namespace X4_ComplexCalculator.Main.Menu.File.Import.LoadoutImport
         /// <summary>
         /// メニュー表示用タイトル
         /// </summary>
-        public string Title { get; private set; }
+        public string Title => "Lang:LoadoutImportTitle";
 
 
         /// <summary>
@@ -26,27 +25,7 @@ namespace X4_ComplexCalculator.Main.Menu.File.Import.LoadoutImport
         /// コンストラクタ
         /// </summary>
         /// <param name="command">Viewより呼ばれるCommand</param>
-        public LoadoutImport(ICommand command)
-        {
-            Command = command;
-            Title = (string)LocalizeDictionary.Instance.GetLocalizedObject("Lang:LoadoutImportTitle", null, null);
-            LocalizeDictionary.Instance.PropertyChanged += Instance_PropertyChanged;
-        }
-
-
-        /// <summary>
-        /// 選択言語変更時
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void Instance_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(LocalizeDictionary.Instance.Culture))
-            {
-                Title = (string)LocalizeDictionary.Instance.GetLocalizedObject("Lang:LoadoutImportTitle", null, null);
-                RaisePropertyChanged(nameof(Title));
-            }
-        }
+        public LoadoutImport(ICommand command) => Command = command;
 
 
         /// <summary>

--- a/X4_ComplexCalculator/Main/Menu/File/Import/StationCalculatorImport.cs
+++ b/X4_ComplexCalculator/Main/Menu/File/Import/StationCalculatorImport.cs
@@ -31,7 +31,7 @@ namespace X4_ComplexCalculator.Main.Menu.File.Import
         /// <summary>
         /// メニュー表示用タイトル
         /// </summary>
-        public string Title => "Station Calculator";
+        public string Title => "Lang:StationCalculator";
 
 
         /// <summary>
@@ -51,10 +51,7 @@ namespace X4_ComplexCalculator.Main.Menu.File.Import
         /// コンストラクタ
         /// </summary>
         /// <param name="command">Viewより呼ばれるCommand</param>
-        public StationCalculatorImport(ICommand command)
-        {
-            Command = command;
-        }
+        public StationCalculatorImport(ICommand command) => Command = command;
 
 
         /// <summary>

--- a/X4_ComplexCalculator/Main/Menu/File/Import/StationPlanImport/StationPlanImport.cs
+++ b/X4_ComplexCalculator/Main/Menu/File/Import/StationPlanImport/StationPlanImport.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Windows.Input;
 using System.Xml.XPath;
 using Prism.Mvvm;
-using WPFLocalizeExtension.Engine;
 using X4_ComplexCalculator.Common.EditStatus;
 using X4_ComplexCalculator.DB;
 using X4_ComplexCalculator.DB.X4DB;
@@ -35,7 +34,7 @@ namespace X4_ComplexCalculator.Main.Menu.File.Import.StationPlanImport
         /// <summary>
         /// メニュー表示用タイトル
         /// </summary>
-        public string Title { get; private set; }
+        public string Title => "Lang:ExistingPlan";
 
 
         /// <summary>
@@ -49,27 +48,7 @@ namespace X4_ComplexCalculator.Main.Menu.File.Import.StationPlanImport
         /// コンストラクタ
         /// </summary>
         /// <param name="command">Viewより呼ばれるCommand</param>
-        public StationPlanImport(ICommand command)
-        {
-            Command = command;
-            Title = (string)LocalizeDictionary.Instance.GetLocalizedObject("Lang:ExistingPlan", null, null);
-            LocalizeDictionary.Instance.PropertyChanged += Instance_PropertyChanged;
-        }
-
-
-        /// <summary>
-        /// 選択言語変更時
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void Instance_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(LocalizeDictionary.Instance.Culture))
-            {
-                Title = (string)LocalizeDictionary.Instance.GetLocalizedObject("Lang:ExistingPlan", null, null);
-                RaisePropertyChanged(nameof(Title));
-            }
-        }
+        public StationPlanImport(ICommand command) => Command = command;
 
 
         /// <summary>

--- a/X4_ComplexCalculator/Main/WorkAreaManager.cs
+++ b/X4_ComplexCalculator/Main/WorkAreaManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.DirectoryServices.Protocols;
 using System.Reactive.Linq;
 using System.Windows;
 using System.Windows.Threading;

--- a/X4_ComplexCalculator/X4_ComplexCalculator.csproj
+++ b/X4_ComplexCalculator/X4_ComplexCalculator.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
     <PackageReference Include="ReactiveProperty" Version="7.1.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.1" />
-    <PackageReference Include="WPFLocalizeExtension" Version="3.6.1" />
+    <PackageReference Include="WPFLocalizeExtension" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- *[WPFLocalizeExtension](https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension)* を [v3.8.0](https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/releases/tag/3.8.0) にアップデート

- *WPFLocalizeExtension* や *[XAMLMarkupExtensions](https://github.com/XAMLMarkupExtensions/XAMLMarkupExtensions)* から *[Microsoft.Windows.Compatibility](https://www.nuget.org/packages/Microsoft.Windows.Compatibility)* への依存が削除されたことに伴う名前空間の修正

- TranslateConverter による言語切替対応のテスト実装

### 言語切替対応のテスト実装

[WPFLocalizeExtensionの公式サンプル](https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/blob/3.8.0/tests/HelloWorldWPF/MainWindow.xaml#L26-L33)を参考にメニューのエクスポートのところの言語切替処理を XAML に移動。
Event を使わずに済むが、無駄に長い。気が向いたらもっと短く書けないか聞いてみる。

### v3.8.0 以降非推奨になった機能

CSVLocalizationProvider とその派生クラスが非推奨になった。
v4.0.0 で削除予定のため、近々 resx への移行か csv 用の `ILocalizationProvider` の自前実装が必要になる。
