### PR TITLE
WPFLocalizeExtensionの非推奨になったクラスを自前実装

### DIFF
--- a/X4_ComplexCalculator/Common/Localize/CSVEmbeddedLocalizationProvider.cs
+++ b/X4_ComplexCalculator/Common/Localize/CSVEmbeddedLocalizationProvider.cs
@@ -1,0 +1,285 @@
+﻿#region Copyright information
+// <copyright file="CSVEmbeddedLocalizationProvider.cs">
+//     Licensed under Microsoft Public License (Ms-PL)
+//     https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/blob/master/LICENSE
+// </copyright>
+// <author>Sébastien Sevrin</author>
+#endregion
+
+
+namespace X4_ComplexCalculator.Common.Localize
+{
+    #region Usings
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Resources;
+    using System.Text;
+    using System.Windows;
+    using WPFLocalizeExtension.Engine;
+    using WPFLocalizeExtension.Providers;
+    using XAMLMarkupExtensions.Base;
+    #endregion
+
+
+    /// <summary>
+    /// A singleton CSV provider that uses attached properties and the Parent property to iterate through the visual tree.
+    /// </summary>
+    public class CSVEmbeddedLocalizationProvider : CSVLocalizationProviderBase
+    {
+        #region Dependency Properties
+        /// <summary>
+        /// <see cref="DependencyProperty"/> DefaultDictionary to set the fallback resource dictionary.
+        /// </summary>
+        public static readonly DependencyProperty DefaultDictionaryProperty =
+                DependencyProperty.RegisterAttached(
+                "DefaultDictionary",
+                typeof(string),
+                typeof(CSVEmbeddedLocalizationProvider),
+                new PropertyMetadata(null, AttachedPropertyChanged));
+
+        /// <summary>
+        /// <see cref="DependencyProperty"/> DefaultAssembly to set the fallback assembly.
+        /// </summary>
+        public static readonly DependencyProperty DefaultAssemblyProperty =
+            DependencyProperty.RegisterAttached(
+                "DefaultAssembly",
+                typeof(string),
+                typeof(CSVEmbeddedLocalizationProvider),
+                new PropertyMetadata(null, AttachedPropertyChanged));
+        #endregion
+
+        #region Dependency Property Callback
+        /// <summary>
+        /// Indicates, that one of the attached properties changed.
+        /// </summary>
+        /// <param name="obj">The dependency object.</param>
+        /// <param name="args">The event argument.</param>
+        private static void AttachedPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
+        {
+            Instance.OnProviderChanged(obj);
+        }
+        #endregion
+
+        #region Dependency Property Management
+        #region Get
+        /// <summary>
+        /// Getter of <see cref="DependencyProperty"/> default dictionary.
+        /// </summary>
+        /// <param name="obj">The dependency object to get the default dictionary from.</param>
+        /// <returns>The default dictionary.</returns>
+        public static string GetDefaultDictionary(DependencyObject obj)
+        {
+            return obj.GetValueSync<string>(DefaultDictionaryProperty);
+        }
+
+        /// <summary>
+        /// Getter of <see cref="DependencyProperty"/> default assembly.
+        /// </summary>
+        /// <param name="obj">The dependency object to get the default assembly from.</param>
+        /// <returns>The default assembly.</returns>
+        public static string GetDefaultAssembly(DependencyObject obj)
+        {
+            return obj.GetValueSync<string>(DefaultAssemblyProperty);
+        }
+        #endregion
+
+        #region Set
+        /// <summary>
+        /// Setter of <see cref="DependencyProperty"/> default dictionary.
+        /// </summary>
+        /// <param name="obj">The dependency object to set the default dictionary to.</param>
+        /// <param name="value">The dictionary.</param>
+        public static void SetDefaultDictionary(DependencyObject obj, string value)
+        {
+            obj.SetValueSync(DefaultDictionaryProperty, value);
+        }
+
+        /// <summary>
+        /// Setter of <see cref="DependencyProperty"/> default assembly.
+        /// </summary>
+        /// <param name="obj">The dependency object to set the default assembly to.</param>
+        /// <param name="value">The assembly.</param>
+        public static void SetDefaultAssembly(DependencyObject obj, string value)
+        {
+            obj.SetValueSync(DefaultAssemblyProperty, value);
+        }
+        #endregion
+        #endregion
+
+        #region Variables
+        /// <summary>
+        /// A dictionary for notification classes for changes of the individual target Parent changes.
+        /// </summary>
+        private readonly ParentNotifiers _parentNotifiers = new ParentNotifiers();
+        #endregion
+
+        #region Singleton Variables, Properties & Constructor
+        /// <summary>
+        /// The instance of the singleton.
+        /// </summary>
+        private static CSVEmbeddedLocalizationProvider? _instance;
+
+        /// <summary>
+        /// Lock object for the creation of the singleton instance.
+        /// </summary>
+        private static readonly object InstanceLock = new object();
+
+        /// <summary>
+        /// Gets the <see cref="CSVEmbeddedLocalizationProvider"/> singleton.
+        /// </summary>
+        public static CSVEmbeddedLocalizationProvider Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    lock (InstanceLock)
+                    {
+                        if (_instance == null)
+                            _instance = new CSVEmbeddedLocalizationProvider();
+                    }
+                }
+
+                // return the existing/new instance
+                return _instance;
+            }
+        }
+
+        /// <summary>
+        /// The singleton constructor.
+        /// </summary>
+        private CSVEmbeddedLocalizationProvider()
+        {
+            ResourceManagerList = new Dictionary<string, ResourceManager>();
+            AvailableCultures = new ObservableCollection<CultureInfo> { CultureInfo.InvariantCulture };
+        }
+
+        private bool _hasHeader;
+        /// <summary>
+        /// A flag indicating, if it has a header row.
+        /// </summary>
+        public bool HasHeader
+        {
+            get => _hasHeader;
+            set => _hasHeader = value;
+        }
+        #endregion
+
+        #region Abstract assembly & dictionary lookup
+        /// <summary>
+        /// An action that will be called when a parent of one of the observed target objects changed.
+        /// </summary>
+        /// <param name="obj">The target <see cref="DependencyObject"/>.</param>
+        private void ParentChangedAction(DependencyObject obj)
+        {
+            OnProviderChanged(obj);
+        }
+
+        /// <summary>
+        /// Get the assembly from the context, if possible.
+        /// </summary>
+        /// <param name="target">The target object.</param>
+        /// <returns>The assembly name, if available.</returns>
+        protected override string GetAssembly(DependencyObject target)
+        {
+            return target?.GetValueOrRegisterParentNotifier<string>(DefaultAssemblyProperty, ParentChangedAction, _parentNotifiers) ?? "";
+        }
+
+        /// <summary>
+        /// Get the dictionary from the context, if possible.
+        /// </summary>
+        /// <param name="target">The target object.</param>
+        /// <returns>The dictionary name, if available.</returns>
+        protected override string GetDictionary(DependencyObject target)
+        {
+            return target?.GetValueOrRegisterParentNotifier<string>(DefaultDictionaryProperty, ParentChangedAction, _parentNotifiers) ?? "";
+        }
+
+        /// <summary>
+        /// Get the localized object.
+        /// </summary>
+        /// <param name="key">The key to the value.</param>
+        /// <param name="target">The target object.</param>
+        /// <param name="culture">The culture to use.</param>
+        /// <returns>The value corresponding to the source/dictionary/key path for the given culture (otherwise NULL).</returns>
+        public override object GetLocalizedObject(string key, DependencyObject target, CultureInfo culture)
+        {
+            string? ret = null;
+
+            var filename = "";
+
+            // Call this function to provide backward compatibility.
+            ParseKey(key, out var assembly, out var dictionary, out key);
+
+            // Now try to read out the default assembly and/or dictionary.
+            if (string.IsNullOrEmpty(assembly))
+                assembly = GetAssembly(target);
+
+            if (string.IsNullOrEmpty(dictionary))
+                dictionary = GetDictionary(target);
+
+            var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            foreach (var assemblyInAppDomain in loadedAssemblies)
+            {
+                if (assemblyInAppDomain == null || string.IsNullOrEmpty(assemblyInAppDomain.FullName))
+                {
+                    continue;
+                }
+
+                // get the assembly name object
+                var assemblyName = new AssemblyName(assemblyInAppDomain.FullName);
+
+                // check if the name of the assembly is the seached one
+                if (assemblyName.Name == assembly)
+                {
+                    //filename = assemblyInAppDomain.GetManifestResourceNames().Where(r => r.Contains(dictionary)).FirstOrDefault();
+                    filename = assemblyInAppDomain.GetManifestResourceNames().FirstOrDefault(r => r.Contains($"{dictionary}{(string.IsNullOrEmpty(culture.Name) ? "" : "-")}{culture.Name}"));
+                    if (filename != null)
+                    {
+                        using (var reader = new StreamReader(assemblyInAppDomain.GetManifestResourceStream(filename) ?? throw new InvalidOperationException(), Encoding.Default))
+                        {
+                            if (HasHeader && !reader.EndOfStream)
+                                reader.ReadLine();
+
+                            // Read each line and split it.
+                            while (!reader.EndOfStream)
+                            {
+                                var line = reader.ReadLine();
+                                if (line != null)
+                                {
+                                    var parts = line.Split(";".ToCharArray());
+
+                                    if (parts.Length < 2)
+                                        continue;
+
+                                    // Check the key (1st column).
+                                    if (parts[0] != key)
+                                        continue;
+
+                                    // Get the value (2nd column).
+                                    ret = parts[1];
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Nothing found -> Raise the error message.
+            if (ret == null)
+            {
+                OnProviderError(target, key, "The key does not exist in " + filename + ".");
+                ret = key;
+            }
+
+            return ret;
+        }
+        #endregion
+    }
+}

--- a/X4_ComplexCalculator/Common/Localize/CSVLocalizationProvider.cs
+++ b/X4_ComplexCalculator/Common/Localize/CSVLocalizationProvider.cs
@@ -16,7 +16,6 @@ using System.Linq;
 using System.Management;
 using System.Text;
 using System.Windows;
-using WPFLocalizeExtension.Deprecated.Providers;
 using WPFLocalizeExtension.Engine;
 using WPFLocalizeExtension.Providers;
 

--- a/X4_ComplexCalculator/Common/Localize/CSVLocalizationProviderBase.cs
+++ b/X4_ComplexCalculator/Common/Localize/CSVLocalizationProviderBase.cs
@@ -1,0 +1,237 @@
+﻿#region Copyright information
+// <copyright file="CSVLocalizationProviderBase.cs">
+//     Licensed under Microsoft Public License (Ms-PL)
+//     https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/blob/master/LICENSE
+// </copyright>
+// <author>Sébastien Sevrin</author>
+#endregion
+
+namespace X4_ComplexCalculator.Common.Localize
+{
+    #region Usings
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+    using System.Resources;
+    using System.Windows;
+    using WPFLocalizeExtension.Providers;
+    #endregion
+
+    /// <summary>
+    /// The base for CSV file providers.
+    /// </summary>
+    public abstract class CSVLocalizationProviderBase : DependencyObject, ILocalizationProvider
+    {
+        #region Variables
+        /// <summary>
+        /// Gets the used ResourceManagers with their corresponding <c>namespaces</c>.
+        /// </summary>
+        protected Dictionary<string, ResourceManager> ResourceManagerList =
+            new Dictionary<string, ResourceManager>();
+
+        /// <summary>
+        /// Lock object for concurrent access to the resource manager list.
+        /// </summary>
+        protected object ResourceManagerListLock = new object();
+
+        /// <summary>
+        /// Lock object for concurrent access to the available culture list.
+        /// </summary>
+        protected object AvailableCultureListLock = new object();
+        #endregion
+
+        #region Helper functions
+        /// <summary>
+        /// Returns the <see cref="AssemblyName"/> of the passed assembly instance
+        /// </summary>
+        /// <param name="assembly">The Assembly where to get the name from</param>
+        /// <returns>The Assembly name</returns>
+        protected string GetAssemblyName(Assembly assembly)
+        {
+            if (assembly.FullName == null)
+                throw new NullReferenceException("assembly.FullName is null");
+
+            return assembly.FullName.Split(',')[0];
+        }
+
+        /// <summary>
+        /// Parses a key ([[Assembly:]Dict:]Key and return the parts of it.
+        /// </summary>
+        /// <param name="inKey">The key to parse.</param>
+        /// <param name="outAssembly">The found or default assembly.</param>
+        /// <param name="outDict">The found or default dictionary.</param>
+        /// <param name="outKey">The found or default key.</param>
+        public static void ParseKey(string inKey, out string outAssembly, out string outDict, out string outKey)
+        {
+            // Reset everything to null.
+            outAssembly = "";
+            outDict = "";
+            outKey = "";
+
+            if (!string.IsNullOrEmpty(inKey))
+            {
+                var split = inKey.Trim().Split(":".ToCharArray());
+
+                // assembly:dict:key
+                if (split.Length == 3)
+                {
+                    outAssembly = split[0];
+                    outDict = split[1];
+                    outKey = split[2];
+                }
+
+                // dict:key
+                if (split.Length == 2)
+                {
+                    outDict = split[0];
+                    outKey = split[1];
+                }
+
+                // key
+                if (split.Length == 1)
+                {
+                    outKey = split[0];
+                }
+            }
+        }
+        #endregion
+
+        #region Abstract assembly & dictionary lookup
+        /// <summary>
+        /// Get the assembly from the context, if possible.
+        /// </summary>
+        /// <param name="target">The target object.</param>
+        /// <returns>The assembly name, if available.</returns>
+        protected abstract string GetAssembly(DependencyObject target);
+
+        /// <summary>
+        /// Get the dictionary from the context, if possible.
+        /// </summary>
+        /// <param name="target">The target object.</param>
+        /// <returns>The dictionary name, if available.</returns>
+        protected abstract string GetDictionary(DependencyObject target);
+        #endregion
+
+        #region Culture Management
+        /// <summary>
+        /// Thread-safe access to the AvailableCultures list.
+        /// </summary>
+        /// <param name="c">The CultureInfo.</param>
+        protected void AddCulture(CultureInfo c)
+        {
+            lock (AvailableCultureListLock)
+            {
+                if (!AvailableCultures.Contains(c))
+                    AvailableCultures.Add(c);
+            }
+        }
+        #endregion
+
+        #region ILocalizationProvider implementation
+        /// <summary>
+        /// Uses the key and target to build a fully qualified resource key (Assembly, Dictionary, Key)
+        /// </summary>
+        /// <param name="key">Key used as a base to find the full key</param>
+        /// <param name="target">Target used to help determine key information</param>
+        /// <returns>Returns an object with all possible pieces of the given key (Assembly, Dictionary, Key)</returns>
+        public FullyQualifiedResourceKeyBase GetFullyQualifiedResourceKey(string key, DependencyObject target)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentNullException(nameof(key));
+
+            ParseKey(key, out var assembly, out var dictionary, out key);
+
+            if (target == null)
+                return new FQAssemblyDictionaryKey(key, assembly, dictionary);
+
+            if (string.IsNullOrEmpty(assembly))
+                assembly = GetAssembly(target);
+
+            if (string.IsNullOrEmpty(dictionary))
+                dictionary = GetDictionary(target);
+
+            return new FQAssemblyDictionaryKey(key, assembly, dictionary);
+        }
+
+        /// <summary>
+        /// Gets fired when the provider changed.
+        /// </summary>
+        public event ProviderChangedEventHandler? ProviderChanged;
+
+        /// <summary>
+        /// An event that is fired when an error occurred.
+        /// </summary>
+        public event ProviderErrorEventHandler? ProviderError;
+
+        /// <summary>
+        /// An event that is fired when a value changed.
+        /// </summary>
+        public event ValueChangedEventHandler? ValueChanged;
+
+        /// <summary>
+        /// Calls the <see cref="ILocalizationProvider.ProviderChanged"/> event.
+        /// </summary>
+        /// <param name="target">The target object.</param>
+        protected virtual void OnProviderChanged(DependencyObject target)
+        {
+            try
+            {
+                var assembly = GetAssembly(target);
+                var dictionary = GetDictionary(target);
+
+                //if (!String.IsNullOrEmpty(assembly) && !String.IsNullOrEmpty(dictionary))
+                //    GetResourceManager(assembly, dictionary);
+            }
+            catch
+            {
+                // ignored
+            }
+
+            ProviderChanged?.Invoke(this, new ProviderChangedEventArgs(target));
+        }
+
+        /// <summary>
+        /// Calls the <see cref="ILocalizationProvider.ProviderError"/> event.
+        /// </summary>
+        /// <param name="target">The target object.</param>
+        /// <param name="key">The key.</param>
+        /// <param name="message">The error message.</param>
+        protected virtual void OnProviderError(DependencyObject target, string key, string message)
+        {
+            ProviderError?.Invoke(this, new ProviderErrorEventArgs(target, key, message));
+        }
+
+        /// <summary>
+        /// Calls the <see cref="ILocalizationProvider.ValueChanged"/> event.
+        /// </summary>
+        /// <param name="key">The key where the value was changed.</param>
+        /// <param name="value">The new value.</param>
+        /// <param name="tag">A custom tag.</param>
+        protected virtual void OnValueChanged(string key, object value, object tag)
+        {
+            ValueChanged?.Invoke(this, new ValueChangedEventArgs(key, value, tag));
+        }
+
+        /// <summary>
+        /// Get the localized object.
+        /// </summary>
+        /// <param name="key">The key to the value.</param>
+        /// <param name="target">The target object.</param>
+        /// <param name="culture">The culture to use.</param>
+        /// <returns>The value corresponding to the source/dictionary/key path for the given culture (otherwise NULL).</returns>
+        public virtual object GetLocalizedObject(string key, DependencyObject target, CultureInfo culture)
+        {
+            throw new InvalidOperationException("GetLocalizedObject needs to be overriden");
+        }
+
+        /// <summary>
+        /// An observable list of available cultures.
+        /// </summary>
+        public ObservableCollection<CultureInfo> AvailableCultures { get; protected set; }
+            = new ObservableCollection<CultureInfo>();
+        #endregion
+    }
+}


### PR DESCRIPTION
WPFLocalizeExtensionの以下のクラスが非推奨になったため自前実装した
1. CSVLocalizationProviderBase
1. CSVEmbeddedLocalizationProvider