### PR TITLE
Fix some .NET5 nullable warning

### DIFF
--- a/LibX4/FileSystem/CatFile.cs
+++ b/LibX4/FileSystem/CatFile.cs
@@ -162,8 +162,10 @@ namespace LibX4.FileSystem
             {
                 foreach (var entry in OpenXml(indexFilePath).XPathSelectElements("/index/entry"))
                 {
-                    var entryName = entry.Attribute("name").Value;
-                    var entryValue = entry.Attribute("value").Value.Replace(@"\\", @"\");
+                    var entryName = entry.Attribute("name")?.Value;
+                    if (entryName == null) continue;
+                    var entryValue = entry.Attribute("value")?.Value.Replace(@"\\", @"\");
+                    if (entryValue == null) continue;
                     if (!_Index.TryAdd(entryName, entryValue)) _Index[entryName] = entryValue;
                 }
                 _LoadedIndex.Add(indexFilePath);

--- a/LibX4/FileSystem/ModInfo.cs
+++ b/LibX4/FileSystem/ModInfo.cs
@@ -60,13 +60,13 @@ namespace LibX4.FileSystem
             var contentXmlPatth = Path.Combine(modDirPath, "content.xml");
             var xml = XDocumentEx.Load(contentXmlPatth);
 
-            ID      = xml.Root.Attribute("id")?.Value      ?? "";
-            Name    = xml.Root.Attribute("name")?.Value    ?? "";
-            Author  = xml.Root.Attribute("author")?.Value  ?? "";
-            Version = xml.Root.Attribute("version")?.Value ?? "";
-            Date    = xml.Root.Attribute("date")?.Value    ?? "";
-            Enabled = xml.Root.Attribute("enabled")?.Value ?? "";
-            Save    = xml.Root.Attribute("save")?.Value    ?? "";
+            ID      = xml.Root?.Attribute("id")?.Value      ?? "";
+            Name    = xml.Root?.Attribute("name")?.Value    ?? "";
+            Author  = xml.Root?.Attribute("author")?.Value  ?? "";
+            Version = xml.Root?.Attribute("version")?.Value ?? "";
+            Date    = xml.Root?.Attribute("date")?.Value    ?? "";
+            Enabled = xml.Root?.Attribute("enabled")?.Value ?? "";
+            Save    = xml.Root?.Attribute("save")?.Value    ?? "";
         }
     }
 }

--- a/LibX4/Lang/LanguageResolver.cs
+++ b/LibX4/Lang/LanguageResolver.cs
@@ -81,7 +81,7 @@ namespace LibX4.Lang
             foreach (var languageXml in _LanguagesXml)
             {
                 var findT = languageXml.Root
-                    .XPathSelectElement($"./page[@id='{pageID}']/t[@id='{tID}']")
+                    ?.XPathSelectElement($"./page[@id='{pageID}']/t[@id='{tID}']")
                     ?.Value;
                 if (findT != null)
                 {

--- a/LibX4/Xml/XAttributeExtension.cs
+++ b/LibX4/Xml/XAttributeExtension.cs
@@ -15,11 +15,12 @@ namespace LibX4.Xml
         /// <param name="attr">値を取得する XML 属性</param>
         /// <returns>変換済みの属性値</returns>
         /// <exception cref="XmlFormatException">属性が無い、または無効な値の場合</exception>
-        public static double GetDouble(this XAttribute attr)
+        public static double GetDouble(this XAttribute? attr)
         {
             try
             {
-                return double.Parse(attr?.Value, CultureInfo.InvariantCulture);
+                var value = attr?.Value ?? throw XmlFormatException.CreateFrom(attr);
+                return double.Parse(value, CultureInfo.InvariantCulture);
             }
             catch (SystemException exception)
             {
@@ -34,11 +35,12 @@ namespace LibX4.Xml
         /// <param name="attr">値を取得する XML 属性</param>
         /// <returns>変換済みの属性値</returns>
         /// <exception cref="XmlFormatException">属性が無い、または無効な値の場合</exception>
-        public static int GetInt(this XAttribute attr)
+        public static int GetInt(this XAttribute? attr)
         {
             try
             {
-                return int.Parse(attr?.Value, CultureInfo.InvariantCulture);
+                var value = attr?.Value ?? throw XmlFormatException.CreateFrom(attr);
+                return int.Parse(value, CultureInfo.InvariantCulture);
             }
             catch (SystemException exception)
             {

--- a/LibX4/Xml/XmlFormatException.cs
+++ b/LibX4/Xml/XmlFormatException.cs
@@ -41,7 +41,8 @@ namespace LibX4.Xml
         /// </summary>
         /// <param name="attr">エラーの発生した XML 属性</param>
         /// <returns>指定の XML 属性の情報で初期化した XmlFormatException</returns>
-        public static XmlFormatException CreateFrom(XAttribute? attr, Exception? innerException)
+        public static XmlFormatException CreateFrom(XAttribute? attr,
+                                                    Exception? innerException = null)
         {
             var exception = new XmlFormatException("XML format is invalid.", innerException);
             exception.Input = attr?.Value ?? "<null>";

--- a/X4_ComplexCalculator/Common/Collection/ObservablePropertyChangedCollection.cs
+++ b/X4_ComplexCalculator/Common/Collection/ObservablePropertyChangedCollection.cs
@@ -14,7 +14,7 @@ namespace X4_ComplexCalculator.Common.Collection
     /// <param name="sender"></param>
     /// <param name="e"></param>
     /// <returns></returns>
-    public delegate Task NotifyCollectionChangedEventAsync(object sender, NotifyCollectionChangedEventArgs e);
+    public delegate Task NotifyCollectionChangedEventAsync(object? sender, NotifyCollectionChangedEventArgs e);
 
     /// <summary>
     /// プロパティ変更時のイベント(非同期)
@@ -81,7 +81,7 @@ namespace X4_ComplexCalculator.Common.Collection
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void CollectionChangedEvent(object sender, NotifyCollectionChangedEventArgs e)
+        private void CollectionChangedEvent(object? sender, NotifyCollectionChangedEventArgs e)
         {
             // 非同期版イベントが購読されていなければ何もしない
             if (CollectionChangedAsync == null)

--- a/X4_ComplexCalculator/DB/X4Database.cs
+++ b/X4_ComplexCalculator/DB/X4Database.cs
@@ -206,7 +206,7 @@ namespace X4_ComplexCalculator.DB
                 }
 
                 // 表示名を保持しているオブジェクトを取得する
-                object value = child.GetValue("DisplayName");
+                var value = child.GetValue("DisplayName");
                 if (value == null)
                 {
                     // 取得に失敗したら次のレジストリを見に行く

--- a/X4_ComplexCalculator/Main/MainWindowViewModel.cs
+++ b/X4_ComplexCalculator/Main/MainWindowViewModel.cs
@@ -320,7 +320,7 @@ namespace X4_ComplexCalculator.Main
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Member_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Member_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/X4_ComplexCalculator/Main/Menu/File/Import/StationPlanImport/SelectPlanViewModel.cs
+++ b/X4_ComplexCalculator/Main/Menu/File/Import/StationPlanImport/SelectPlanViewModel.cs
@@ -106,7 +106,7 @@ namespace X4_ComplexCalculator.Main.Menu.File.Import.StationPlanImport
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void Model_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/X4_ComplexCalculator/Main/Menu/View/EmpireOverview/EmpireOverviewWindowModel.cs
+++ b/X4_ComplexCalculator/Main/Menu/View/EmpireOverview/EmpireOverviewWindowModel.cs
@@ -78,7 +78,7 @@ namespace X4_ComplexCalculator.Main.Menu.View.EmpireOverview
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void WorkAreas_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void WorkAreas_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.OldItems != null)
             {
@@ -153,7 +153,7 @@ namespace X4_ComplexCalculator.Main.Menu.View.EmpireOverview
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Products_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Products_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (!(sender is ObservableCollection<ProductsGridItem> products))
             {
@@ -212,7 +212,7 @@ namespace X4_ComplexCalculator.Main.Menu.View.EmpireOverview
                 {
                     prod.Count -= removedItem.Count;
                 }
-                
+
                 prodBak.Remove(removedItem);
             }
 

--- a/X4_ComplexCalculator/Main/WorkArea/UI/BuildResourcesGrid/BuildResourcesGridModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/BuildResourcesGrid/BuildResourcesGridModel.cs
@@ -141,7 +141,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.BuildResourcesGrid
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private async Task OnModulesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private async Task OnModulesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/ContextMenuOperation.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/ContextMenuOperation.cs
@@ -108,7 +108,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid
             _ModulesInfo    = modulesInfo;
             _CollectionView = listCollectionView;
             _ModuleReorder  = new ModulesReorder(modulesInfo, listCollectionView);
-            
+
             ((INotifyCollectionChanged)_CollectionView.SortDescriptions).CollectionChanged += ContextMenuOperation_CollectionChanged;
 
             CopyModulesCommand    = new DelegateCommand(CopyModules);
@@ -133,7 +133,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void ContextMenuOperation_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void ContextMenuOperation_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             // 未ソートの場合のみ入れ替え可能にする
             _ModuleReorder.SortedColumnCount = _CollectionView.SortDescriptions.Count;
@@ -213,7 +213,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid
             var items = CollectionViewSource.GetDefaultView(_CollectionView)
                                             .Cast<ModulesGridItem>()
                                             .Where(x => x.IsSelected);
-            
+
             _ModulesInfo.Modules.RemoveRange(items);
 
             // 削除後に全部の選択状態を外さないと余計なものまで選択される

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EditEquipmentViewModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EditEquipmentViewModel.cs
@@ -237,7 +237,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid.EditEquipment
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Model_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Model_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EquipmentList/EquipmentListModelBase.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EquipmentList/EquipmentListModelBase.cs
@@ -139,7 +139,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid.EditEquipment.Equipm
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        public abstract void OnPresetsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e);
+        public abstract void OnPresetsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e);
 
 
         /// <summary>

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EquipmentList/EquipmentListViewModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EquipmentList/EquipmentListViewModel.cs
@@ -221,7 +221,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid.EditEquipment.Equipm
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        public void OnPresetsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        public void OnPresetsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             _Model.OnPresetsCollectionChanged(sender, e);
             Unsaved = true;

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EquipmentList/ShieldEquipmentListModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EquipmentList/ShieldEquipmentListModel.cs
@@ -65,7 +65,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid.EditEquipment.Equipm
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        public override void OnPresetsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        public override void OnPresetsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.Action == NotifyCollectionChangedAction.Replace ||
                 e.Action == NotifyCollectionChangedAction.Remove)

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EquipmentList/TurretEquipmentListModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/EditEquipment/EquipmentList/TurretEquipmentListModel.cs
@@ -65,7 +65,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid.EditEquipment.Equipm
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        public override void OnPresetsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        public override void OnPresetsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.Action == NotifyCollectionChangedAction.Replace ||
                 e.Action == NotifyCollectionChangedAction.Remove)

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/ModulesGridItem.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/ModulesGridItem.cs
@@ -207,11 +207,8 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid
             ModuleEquipment = new ModuleEquipment(Module);
 
             ModuleCount = long.Parse(element.Attribute("count").Value);
-            SelectedMethod = Module.ModuleProductions.FirstOrDefault(x => x.Method == element.Attribute("method").Value);
-            if (SelectedMethod == null)
-            {
-                SelectedMethod = Module.ModuleProductions.First();
-            }
+            SelectedMethod = Module.ModuleProductions.FirstOrDefault(x => x.Method == element.Attribute("method")?.Value)
+                ?? Module.ModuleProductions.First();
             _SelectedMethod = SelectedMethod;
             EditEquipmentCommand = new DelegateCommand(EditEquipment);
 

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/ModulesGridModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ModulesGrid/ModulesGridModel.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
-using System.Xml.Linq;
 using X4_ComplexCalculator.Common.Collection;
 using X4_ComplexCalculator.Common.EditStatus;
 using X4_ComplexCalculator.Common.Localize;
@@ -57,7 +55,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ModulesGrid
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void LocalizeInstance_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void LocalizeInstance_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(WPFLocalizeExtension.Engine.LocalizeDictionary.Instance.Culture))
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGridModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGridModel.cs
@@ -101,7 +101,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ProductsGrid
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Workforce_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Workforce_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -121,7 +121,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ProductsGrid
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -272,7 +272,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.ProductsGrid
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private async Task OnModulesChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private async Task OnModulesChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/BuildingCost/BuildingCostModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/BuildingCost/BuildingCostModel.cs
@@ -109,7 +109,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StationSummary.BuildingCost
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Resources_OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Resources_OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/Profit/ProfitModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/Profit/ProfitModel.cs
@@ -69,7 +69,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StationSummary.Profit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnProductsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void OnProductsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             // 製品が削除された場合
             if (e.OldItems != null)

--- a/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/StationSummaryViewModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/StationSummaryViewModel.cs
@@ -10,9 +10,6 @@ using X4_ComplexCalculator.Main.WorkArea.UI.StationSummary.Profit;
 using X4_ComplexCalculator.Main.WorkArea.UI.StationSummary.WorkForce.ModuleInfo;
 using X4_ComplexCalculator.Main.WorkArea.UI.StationSummary.WorkForce.NeedWareInfo;
 using X4_ComplexCalculator.Main.WorkArea.WorkAreaData;
-using X4_ComplexCalculator.Main.WorkArea.WorkAreaData.BuildResources;
-using X4_ComplexCalculator.Main.WorkArea.WorkAreaData.Modules;
-using X4_ComplexCalculator.Main.WorkArea.WorkAreaData.Products;
 using X4_ComplexCalculator.Main.WorkArea.WorkAreaData.StationSettings;
 
 namespace X4_ComplexCalculator.Main.WorkArea.UI.StationSummary
@@ -142,7 +139,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StationSummary
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void ProfitModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void ProfitModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -161,7 +158,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StationSummary
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void BuildingCostModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void BuildingCostModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/WorkForce/ModuleInfo/WorkForceModuleInfoModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/WorkForce/ModuleInfo/WorkForceModuleInfoModel.cs
@@ -67,7 +67,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StationSummary.WorkForce.ModuleI
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -161,7 +161,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StationSummary.WorkForce.ModuleI
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private async Task OnModulesChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private async Task OnModulesChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/WorkForce/NeedWareInfo/NeedWareInfoModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/StationSummary/WorkForce/NeedWareInfo/NeedWareInfoModel.cs
@@ -153,7 +153,7 @@ WHERE
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Modules_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Modules_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             var addWares = new Dictionary<string, Dictionary<string, long>>();
 
@@ -348,7 +348,7 @@ WHERE
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Products_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Products_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             System.Collections.IList[] items = { e.NewItems, e.OldItems };
 

--- a/X4_ComplexCalculator/Main/WorkArea/UI/StorageAssign/StorageAssignGridItem.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/StorageAssign/StorageAssignGridItem.cs
@@ -206,7 +206,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StorageAssign
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void CapacityInfo_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void CapacityInfo_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/StorageAssign/StorageAssignModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/StorageAssign/StorageAssignModel.cs
@@ -146,7 +146,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StorageAssign
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Storages_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Storages_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null)
             {
@@ -204,7 +204,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StorageAssign
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Products_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Products_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/UI/StoragesGrid/StoragesGridModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/StoragesGrid/StoragesGridModel.cs
@@ -106,7 +106,7 @@ namespace X4_ComplexCalculator.Main.WorkArea.UI.StoragesGrid
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private async Task OnModulesChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private async Task OnModulesChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.NewItems != null)
             {

--- a/X4_ComplexCalculator/Main/WorkArea/WorkAreaModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/WorkAreaModel.cs
@@ -129,7 +129,7 @@ namespace X4_ComplexCalculator.Main.WorkArea
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnModulesChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void OnModulesChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             HasChanged = true;
         }
@@ -140,7 +140,7 @@ namespace X4_ComplexCalculator.Main.WorkArea
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             string[] names =
             {

--- a/X4_ComplexCalculator/Main/WorkArea/WorkAreaViewModel.cs
+++ b/X4_ComplexCalculator/Main/WorkArea/WorkAreaViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -176,7 +176,7 @@ namespace X4_ComplexCalculator.Main.WorkArea
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Instance_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void Instance_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(LocalizeDictionary.Instance.Culture) && _CurrentDockingManager != null)
             {
@@ -411,7 +411,7 @@ WHERE
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void Model_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/X4_DataExporterWPF/Export/Equipment/EquipmentExporter.cs
+++ b/X4_DataExporterWPF/Export/Equipment/EquipmentExporter.cs
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS Equipment
                 var equipmentID = equipment.Attribute("id")?.Value;
                 if (string.IsNullOrEmpty(equipmentID)) continue;
 
-                var macroName = equipment.XPathSelectElement("component").Attribute("ref")?.Value;
+                var macroName = equipment.XPathSelectElement("component")?.Attribute("ref")?.Value;
                 if (string.IsNullOrEmpty(macroName)) continue;
 
                 var equipmentTypeID = equipment.Attribute("group")?.Value;
@@ -117,7 +117,7 @@ CREATE TABLE IF NOT EXISTS Equipment
                 string[] sizes = { "extrasmall", "small", "medium", "large", "extralarge" };
 
                 // 一致するサイズを探す
-                var tags = component?.Attribute("tags").Value.Split(" ");
+                var tags = component?.Attribute("tags")?.Value.Split(" ");
                 var sizeID = sizes.FirstOrDefault(x => tags?.Contains(x) == true);
                 // 一致するサイズがなかった場合
                 if (string.IsNullOrEmpty(sizeID)) continue;

--- a/X4_DataExporterWPF/Export/Module/ModuleProductExporter.cs
+++ b/X4_DataExporterWPF/Export/Module/ModuleProductExporter.cs
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS ModuleProduct
         {
             foreach (var module in _WaresXml.Root.XPathSelectElements("ware[contains(@tags, 'module')]"))
             {
-                var moduleID = module.Attribute("id").Value;
+                var moduleID = module.Attribute("id")?.Value;
                 if (string.IsNullOrEmpty(moduleID)) continue;
 
                 var macroName = module.XPathSelectElement("component").Attribute("ref").Value;
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS ModuleProduct
                 var wareID = prod?.Attribute("wares")?.Value;
                 if (string.IsNullOrEmpty(wareID)) continue;
 
-                var method = prod.XPathSelectElement("queue")?.Attribute("method")?.Value ?? "default";
+                var method = prod?.XPathSelectElement("queue")?.Attribute("method")?.Value ?? "default";
 
                 yield return new ModuleProduct(moduleID, wareID, method);
             }


### PR DESCRIPTION
.NET5 で null 許容参照型の属性が付いたクラスによる警告がたくさん増えた(192個くらい)のですぐに直せる一部のみ修正。
主に `XDocument#Root` や `XElement#Attribute(XName)` に nullable が付いたのが厄介。