### PR TITLE
Fixed slider width in Build resources and Products

### DIFF
--- a/X4_ComplexCalculator/Main/WorkArea/UI/BuildResourcesGrid/BuildResourcesGrid.xaml
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/BuildResourcesGrid/BuildResourcesGrid.xaml
@@ -143,6 +143,7 @@
                 <DataGridTemplateColumn.Header>
                     <DockPanel>
                         <Slider
+                            Width="100"
                             DockPanel.Dock="Left"
                             Maximum="100"
                             Minimum="0"
@@ -155,6 +156,8 @@
                 <DataGridTemplateColumn.CellTemplate>
                     <DataTemplate>
                         <Slider
+                            Width="100"
+                            Margin="1,0,0,0"
                             VerticalContentAlignment="Center"
                             Maximum="{Binding Ware.MaxPrice}"
                             Minimum="{Binding Ware.MinPrice}"

--- a/X4_ComplexCalculator/Main/WorkArea/UI/BuildResourcesGrid/BuildResourcesGrid.xaml
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/BuildResourcesGrid/BuildResourcesGrid.xaml
@@ -130,23 +130,18 @@
                 <!--  ヘッダのスタイル定義  -->
                 <DataGridTemplateColumn.HeaderStyle>
                     <Style TargetType="DataGridColumnHeader">
-                        <Setter Property="HorizontalAlignment" Value="Stretch" />
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         <Setter Property="Padding" Value="0" />
                     </Style>
                 </DataGridTemplateColumn.HeaderStyle>
 
                 <!--  ヘッダの内容定義  -->
                 <DataGridTemplateColumn.Header>
-                    <DockPanel>
-                        <Slider
-                            Width="100"
-                            DockPanel.Dock="Left"
-                            Maximum="100"
-                            Minimum="0"
-                            TickFrequency="1"
-                            Value="{Binding Data, Source={StaticResource ProxyUnitPricePercent}, Converter={StaticResource SliderValueConverter}, ConverterParameter=50.0}" />
-                    </DockPanel>
+                    <Slider
+                        Width="100"
+                        Maximum="100"
+                        Minimum="0"
+                        TickFrequency="1"
+                        Value="{Binding Data, Source={StaticResource ProxyUnitPricePercent}, Converter={StaticResource SliderValueConverter}, ConverterParameter=50.0}" />
                 </DataGridTemplateColumn.Header>
 
                 <!--  セルの内容定義  -->
@@ -154,8 +149,7 @@
                     <DataTemplate>
                         <Slider
                             Width="100"
-                            Margin="1,0,0,0"
-                            VerticalContentAlignment="Center"
+                            Margin="1,2,0,0"
                             Maximum="{Binding Ware.MaxPrice}"
                             Minimum="{Binding Ware.MinPrice}"
                             Value="{Binding UnitPrice, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/X4_ComplexCalculator/Main/WorkArea/UI/BuildResourcesGrid/BuildResourcesGrid.xaml
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/BuildResourcesGrid/BuildResourcesGrid.xaml
@@ -126,10 +126,7 @@
 
 
             <!--  単価(スライダー)  -->
-            <DataGridTemplateColumn
-                MinWidth="100"
-                IsReadOnly="True"
-                SortMemberPath="UnitPrice">
+            <DataGridTemplateColumn CanUserResize="False">
                 <!--  ヘッダのスタイル定義  -->
                 <DataGridTemplateColumn.HeaderStyle>
                     <Style TargetType="DataGridColumnHeader">

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGrid.xaml
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGrid.xaml
@@ -229,23 +229,18 @@
                 <!--  ヘッダのスタイル定義  -->
                 <DataGridTemplateColumn.HeaderStyle>
                     <Style TargetType="DataGridColumnHeader">
-                        <Setter Property="HorizontalAlignment" Value="Stretch" />
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         <Setter Property="Padding" Value="0" />
                     </Style>
                 </DataGridTemplateColumn.HeaderStyle>
 
                 <!--  ヘッダの内容定義  -->
                 <DataGridTemplateColumn.Header>
-                    <DockPanel>
-                        <Slider
-                            Width="100"
-                            DockPanel.Dock="Left"
-                            Maximum="100"
-                            Minimum="0"
-                            TickFrequency="1"
-                            Value="{Binding Data, Source={StaticResource ProxyUnitPricePercent}, Converter={StaticResource SliderValueConverter}, ConverterParameter=50.0}" />
-                    </DockPanel>
+                    <Slider
+                        Width="100"
+                        Maximum="100"
+                        Minimum="0"
+                        TickFrequency="1"
+                        Value="{Binding Data, Source={StaticResource ProxyUnitPricePercent}, Converter={StaticResource SliderValueConverter}, ConverterParameter=50.0}" />
                 </DataGridTemplateColumn.Header>
 
                 <!--  セルの内容定義  -->
@@ -253,8 +248,7 @@
                     <DataTemplate>
                         <Slider
                             Width="100"
-                            Margin="1,0,0,0"
-                            VerticalContentAlignment="Center"
+                            Margin="1,2,0,0"
                             Maximum="{Binding Ware.MaxPrice}"
                             Minimum="{Binding Ware.MinPrice}"
                             Value="{Binding UnitPrice, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGrid.xaml
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGrid.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="X4_ComplexCalculator.Main.WorkArea.UI.ProductsGrid.ProductsGrid"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -242,7 +242,7 @@
                             Width="100"
                             DockPanel.Dock="Left"
                             Maximum="100"
-                            Minimum="1"
+                            Minimum="0"
                             TickFrequency="1"
                             Value="{Binding Data, Source={StaticResource ProxyUnitPricePercent}, Converter={StaticResource SliderValueConverter}, ConverterParameter=50.0}" />
                     </DockPanel>

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGrid.xaml
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGrid.xaml
@@ -225,7 +225,7 @@
 
 
             <!--  単価(スライダー)  -->
-            <DataGridTemplateColumn MinWidth="100">
+            <DataGridTemplateColumn CanUserResize="False">
                 <!--  ヘッダのスタイル定義  -->
                 <DataGridTemplateColumn.HeaderStyle>
                     <Style TargetType="DataGridColumnHeader">

--- a/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGrid.xaml
+++ b/X4_ComplexCalculator/Main/WorkArea/UI/ProductsGrid/ProductsGrid.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="X4_ComplexCalculator.Main.WorkArea.UI.ProductsGrid.ProductsGrid"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -239,6 +239,7 @@
                 <DataGridTemplateColumn.Header>
                     <DockPanel>
                         <Slider
+                            Width="100"
                             DockPanel.Dock="Left"
                             Maximum="100"
                             Minimum="1"
@@ -251,6 +252,8 @@
                 <DataGridTemplateColumn.CellTemplate>
                     <DataTemplate>
                         <Slider
+                            Width="100"
+                            Margin="1,0,0,0"
                             VerticalContentAlignment="Center"
                             Maximum="{Binding Ware.MaxPrice}"
                             Minimum="{Binding Ware.MinPrice}"


### PR DESCRIPTION
- 製品タブと建造タブのスライダーの長さを 100 に固定（スライダーのズレ修正のため）
- 製品タブのヘッダスライダーを最小値に設定しても、最低価格にならないウェアがある不具合を修正
- 製品タブと建造タブのスライダー列をリサイズ不可に変更
- 不要になったスタイルや属性などの削除